### PR TITLE
Conan support

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,31 @@
+from conans import ConanFile, CMake
+
+import os
+
+
+class CMark(ConanFile):
+    name = 'cmark'
+    url = 'https://github.com/sztomi/cmark'
+    settings = 'os', 'compiler', 'build_type', 'arch'
+    license = 'MIT'
+    version = '0.27.1'
+    exports = '*'
+    generators = 'cmake'
+
+    def build(self):
+        cmake = CMake(self.settings)
+        os.mkdir('build')
+        os.chdir('build')
+        self.run('cmake {} {} -DCMAKE_INSTALL_PREFIX={}'
+                    .format(self.conanfile_directory,
+                            cmake.command_line,
+                            self.package_folder))
+        self.run('cmake --build .')
+        self.run('make install')
+
+    def package(self):
+        # build() also installs
+        pass
+
+    def package_info(self):
+        self.cpp_info.libs = ['cmark']

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,12 +2,11 @@ from conans import ConanFile, CMake
 
 import os
 
-
 class CMark(ConanFile):
     name = 'cmark'
     url = 'https://github.com/sztomi/cmark'
     settings = 'os', 'compiler', 'build_type', 'arch'
-    license = 'MIT'
+    license = 'BSD2'
     version = '0.27.1'
     exports = '*'
     generators = 'cmake'


### PR DESCRIPTION
I've added a conanfile.py to support uploading cmark to conan.io, which makes it easy to integrate with other projects. I've already created a [package](https://www.conan.io/source/cmark/0.27.1/sztomi/cmark) from my fork, and if this patch is accepted I suggest changing the URL in conanfile.py to the upstream repo. I branched off from the last release tag, so what's uploaded to conan is 0.27.1.