### PR TITLE
> 32 nested balanced parens in a link is bananas

### DIFF
--- a/src/inlines.c
+++ b/src/inlines.c
@@ -850,6 +850,8 @@ static bufsize_t manual_scan_link_url(cmark_chunk *input, bufsize_t offset) {
       else if (input->data[i] == '(') {
         ++nb_p;
         ++i;
+        if (nb_p > 32)
+          return -1;
       } else if (input->data[i] == ')') {
         if (nb_p == 0)
           break;


### PR DESCRIPTION
Fixes https://github.com/jgm/cmark/issues/214 in this fork.

(This is what #216 should have been.)

/cc @mity @vmg