### PR TITLE
`make format` the source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ To run a test for memory leaks using `valgrind`:
 
     make leakcheck
 
-To reformat source code using `astyle`:
+To reformat source code using `clang-format`:
 
-    make astyle
+    make format
 
 To run a "fuzz test" against ten long randomly generated inputs:
 

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -615,7 +615,7 @@ static delimiter *S_insert_emph(subject *subj, delimiter *opener,
   cmark_node *tmp, *tmpnext, *emph;
 
   // calculate the actual number of characters used from this closer
-  use_delims = (closer_num_chars >= 2 && opener_num_chars >=2) ? 2 : 1;
+  use_delims = (closer_num_chars >= 2 && opener_num_chars >= 2) ? 2 : 1;
 
   // remove used characters from associated inlines.
   opener_num_chars -= use_delims;
@@ -821,7 +821,8 @@ noMatch:
   return 0;
 }
 
-static bufsize_t manual_scan_link_url_2(cmark_chunk *input, bufsize_t offset, cmark_chunk *output) {
+static bufsize_t manual_scan_link_url_2(cmark_chunk *input, bufsize_t offset,
+                                        cmark_chunk *output) {
   bufsize_t i = offset;
   size_t nb_p = 0;
 
@@ -854,7 +855,8 @@ static bufsize_t manual_scan_link_url_2(cmark_chunk *input, bufsize_t offset, cm
   return i - offset;
 }
 
-static bufsize_t manual_scan_link_url(cmark_chunk *input, bufsize_t offset, cmark_chunk *output) {
+static bufsize_t manual_scan_link_url(cmark_chunk *input, bufsize_t offset,
+                                      cmark_chunk *output) {
   bufsize_t i = offset;
 
   if (i < input->len && input->data[i] == '<') {
@@ -924,7 +926,8 @@ static cmark_node *handle_close_bracket(subject *subj) {
   // First, look for an inline link.
   if (peek_char(subj) == '(' &&
       ((sps = scan_spacechars(&subj->input, subj->pos + 1)) > -1) &&
-      ((n = manual_scan_link_url(&subj->input, subj->pos + 1 + sps, &url_chunk)) > -1)) {
+      ((n = manual_scan_link_url(&subj->input, subj->pos + 1 + sps,
+                                 &url_chunk)) > -1)) {
 
     // try to parse an explicit link:
     endurl = subj->pos + 1 + sps + n;

--- a/src/latex.c
+++ b/src/latex.c
@@ -252,24 +252,24 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       CR();
       list_number = cmark_node_get_list_start(node);
       if (list_number > 1) {
-	enumlevel = S_get_enumlevel(node);
-	// latex normally supports only five levels
-	if (enumlevel >= 1 && enumlevel <= 5) {
+        enumlevel = S_get_enumlevel(node);
+        // latex normally supports only five levels
+        if (enumlevel >= 1 && enumlevel <= 5) {
           snprintf(list_number_string, LIST_NUMBER_STRING_SIZE, "%d",
                    list_number);
           LIT("\\setcounter{enum");
-          switch(enumlevel) {
-	  case 1: LIT("i"); break;
-	  case 2: LIT("ii"); break;
-	  case 3: LIT("iii"); break;
-	  case 4: LIT("iv"); break;
-	  case 5: LIT("v"); break;
-	  default: LIT("i"); break;
+          switch (enumlevel) {
+          case 1: LIT("i"); break;
+          case 2: LIT("ii"); break;
+          case 3: LIT("iii"); break;
+          case 4: LIT("iv"); break;
+          case 5: LIT("v"); break;
+          default: LIT("i"); break;
 	  }
           LIT("}{");
           OUT(list_number_string, false, NORMAL);
           LIT("}");
-	}
+        }
         CR();
       }
     } else {


### PR DESCRIPTION
This PR updates README because the old `make astyle` is already gone, and reformats the source code with `make format`. I only picked the "obviously good" changes though since some other changes look not as good, especially when it tried to break manual alignments. This was with clang-format 3.9.1.