### PR TITLE
blocks: Fix quadratic behavior in `finalize`

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -255,17 +255,21 @@ static cmark_node *finalize(cmark_parser *parser, cmark_node *b) {
 
   switch (S_type(b)) {
   case CMARK_NODE_PARAGRAPH:
-    while (cmark_strbuf_at(node_content, 0) == '[' &&
-           (pos = cmark_parse_reference_inline(parser->mem, node_content,
-                                               parser->refmap))) {
+  {
+    cmark_chunk chunk = {node_content->ptr, node_content->size, 0};
+    while (chunk.len && chunk.data[0] == '[' &&
+           (pos = cmark_parse_reference_inline(parser->mem, &chunk, parser->refmap))) {
 
-      cmark_strbuf_drop(node_content, pos);
+      chunk.data += pos;
+      chunk.len -= pos;
     }
+    cmark_strbuf_drop(node_content, (node_content->size - chunk.len));
     if (is_blank(node_content, 0)) {
       // remove blank node (former reference def)
       cmark_node_free(b);
     }
     break;
+  }
 
   case CMARK_NODE_CODE_BLOCK:
     if (!b->as.code.fenced) { // indented code

--- a/src/inlines.h
+++ b/src/inlines.h
@@ -11,7 +11,7 @@ cmark_chunk cmark_clean_title(cmark_mem *mem, cmark_chunk *title);
 void cmark_parse_inlines(cmark_mem *mem, cmark_node *parent,
                          cmark_reference_map *refmap, int options);
 
-bufsize_t cmark_parse_reference_inline(cmark_mem *mem, cmark_strbuf *input,
+bufsize_t cmark_parse_reference_inline(cmark_mem *mem, cmark_chunk *input,
                                        cmark_reference_map *refmap);
 
 #ifdef __cplusplus


### PR DESCRIPTION
We had a bug bounty report where consecutive reference definitions take a long time in _parse_, rather than reference lookup.  Here's a repro:

```
~/github/cmark upstream-master$ time python -c 'print("[a]: u\n" * 1 * 50000)' | build/src/cmark
build/src/cmark  0.51s user 0.01s system 93% cpu 0.553 total
~/github/cmark upstream-master$ time python -c 'print("[a]: u\n" * 2 * 50000)' | build/src/cmark
build/src/cmark  1.71s user 0.00s system 98% cpu 1.735 total
~/github/cmark upstream-master$ time python -c 'print("[a]: u\n" * 3 * 50000)' | build/src/cmark
build/src/cmark  3.66s user 0.03s system 98% cpu 3.723 total
~/github/cmark upstream-master$ time python -c 'print("[a]: u\n" * 4 * 50000)' | build/src/cmark
build/src/cmark  6.46s user 0.02s system 99% cpu 6.539 total
~/github/cmark upstream-master$ time python -c 'print("[a]: u\n" * 5 * 50000)' | build/src/cmark
build/src/cmark  9.61s user 0.07s system 99% cpu 9.755 total
~/github/cmark upstream-master$ time python -c 'print("[a]: u\n" * 16 * 50000)' | build/src/cmark
build/src/cmark  106.81s user 0.71s system 99% cpu 1:48.26 total
```

More details to follow, but @vmg put this fix together which is live on our end now.