### PR TITLE
Include GNUInstallDirs in src/CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@ if(${CMAKE_VERSION} VERSION_GREATER "3.3")
     cmake_policy(SET CMP0063 NEW)
 endif()
 
+include(GNUInstallDirs)
+
 set(LIBRARY "libcmark")
 set(STATICLIBRARY "libcmark_static")
 set(HEADERS


### PR DESCRIPTION
Fixes installation error under some CMake versions, notably kalakris'
CMake backport often used with Travis.