### PR TITLE
install cmake exports to lib/cmark

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,7 +148,7 @@ if(CMARK_SHARED OR CMARK_STATIC)
     DESTINATION include
     )
 
-  install(EXPORT cmark DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+  install(EXPORT cmark DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmark)
 endif()
 
 # Feature tests


### PR DESCRIPTION
`lib/cmark/…`, not `lib/cmake/…`. Project names are too similar!