### PR TITLE
Add static export header & deny building both shared and static at once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,13 @@ set(PROJECT_VERSION_PATCH 3)
 set(PROJECT_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} )
 
 option(CMARK_TESTS "Build cmark tests and enable testing" ON)
-option(CMARK_STATIC "Build static libcmark library" ON)
+option(CMARK_STATIC "Build static libcmark library" OFF)
 option(CMARK_SHARED "Build shared libcmark library" ON)
 option(CMARK_LIB_FUZZER "Build libFuzzer fuzzing harness" OFF)
+
+if(CMARK_STATIC AND CMARK_SHARED)
+  message(FATAL_ERROR "You cannot build both the shared and static libcmark library at the same time -- they generate different export headers.")
+endif()
 
 add_subdirectory(src)
 if(CMARK_TESTS AND CMARK_SHARED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,9 @@ if (CMARK_STATIC)
       VERSION ${PROJECT_VERSION})
   endif(MSVC)
 
+  generate_export_header(${STATICLIBRARY}
+    BASE_NAME ${PROJECT_NAME})
+
   list(APPEND CMARK_INSTALL ${STATICLIBRARY})
 endif()
 


### PR DESCRIPTION
Fixes https://github.com/commonmark/cmark/issues/247 by adding an export header for the static library, and denying building both shared and static (due to issues raised in https://github.com/commonmark/cmark/issues/247#issuecomment-344142209).

/cc @nwellnhof