### PR TITLE
Test static-only build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ language: c
 compiler:
  - clang
  - gcc
+matrix:
+  include:
+  - os: linux
+    compiler: gcc
+    env: CMAKE_OPTIONS="-DCMARK_SHARED=OFF"
 addons:
   apt:
     # we need a more recent cmake than travis/linux provides (at least 2.8.9):
@@ -26,7 +31,7 @@ before_install:
      fi
 
 script:
- - make
+ - (mkdir -p build && cd build && cmake $CMAKE_OPTIONS ..)
  - make test
  - |
      if [ ${TRAVIS_OS_NAME:-'linux'} = 'linux' ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ option(CMARK_SHARED "Build shared libcmark library" ON)
 option(CMARK_LIB_FUZZER "Build libFuzzer fuzzing harness" OFF)
 
 add_subdirectory(src)
-if(CMARK_TESTS AND CMARK_SHARED)
+if(CMARK_TESTS AND (CMARK_SHARED OR CMARK_STATIC))
   add_subdirectory(api_test)
 endif()
 add_subdirectory(man)

--- a/api_test/CMakeLists.txt
+++ b/api_test/CMakeLists.txt
@@ -8,7 +8,11 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/src
   ${PROJECT_BINARY_DIR}/src
 )
-target_link_libraries(api_test libcmark)
+if(CMARK_SHARED)
+  target_link_libraries(api_test libcmark)
+else()
+  target_link_libraries(api_test libcmark_static)
+endif()
 
 # Compiler flags
 if(MSVC)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ else(SPEC_TESTS)
   find_package(PythonInterp 3)
 endif(SPEC_TESTS)
 
-if (CMARK_SHARED)
+if (CMARK_SHARED OR CMARK_STATIC)
   add_test(NAME api_test COMMAND api_test)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,14 +41,14 @@ IF (PYTHONINTERP_FOUND)
       "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
       )
 
-    add_test(roundtriptest_executable
+    add_test(roundtriptest_library
       ${PYTHON_EXECUTABLE}
       "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py"
       "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt"
       "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
       )
 
-    add_test(entity_executable
+    add_test(entity_library
       ${PYTHON_EXECUTABLE}
       "${CMAKE_CURRENT_SOURCE_DIR}/entity_tests.py"
       "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"


### PR DESCRIPTION
Some of the "library" tests could also be made to run against the executable when building without a shared library, but it's not that important.