### PR TITLE
Check for empty buffer when rendering

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -171,7 +171,7 @@ char *cmark_render(cmark_node *root, int options, int width,
   }
 
   // ensure final newline
-  if (renderer.buffer->ptr[renderer.buffer->size - 1] != '\n') {
+  if (renderer.buffer->size == 0 || renderer.buffer->ptr[renderer.buffer->size - 1] != '\n') {
     cmark_strbuf_putc(renderer.buffer, '\n');
   }
 

--- a/test/cmark-fuzz.c
+++ b/test/cmark-fuzz.c
@@ -4,7 +4,7 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   int options = 0;
-  if (size > sizeof(options)) {
+  if (size >= sizeof(options)) {
     /* First 4 bytes of input are treated as options */
     int options = *(const int *)data;
 


### PR DESCRIPTION
This minor bug came in via GitHub's Bug Bounty program. I did some digging and we didn't find this bug via fuzzing because we discard all empty documents in `test/cmark-fuzz.c`. I tweaked the fuzzing harness to accept empty documents.

I also noticed we use a fixed width when fuzzing. Allow the `width` parameter to be fuzzed too for better coverage.