### PR TITLE
build: only attempt to install MSVC system libraries on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,11 +128,13 @@ if (MSVC)
     APPEND PROPERTY LINK_FLAGS /INCREMENTAL:NO)
 endif(MSVC)
 
-set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
+if(NOT MSVC OR CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
+  set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
+  include(InstallRequiredSystemLibraries)
+endif()
 
 set(libdir lib${LIB_SUFFIX})
 
-include (InstallRequiredSystemLibraries)
 install(TARGETS ${PROGRAM} ${CMARK_INSTALL}
   EXPORT cmark
   RUNTIME DESTINATION bin


### PR DESCRIPTION
Newer versions of CMake attempt to query the system for information about the VS
2017 installation.  Unfortunately, this query fails on non-Windows systems when
cross-compiling:

	cmake_host_system_information does not recognize <key> VS_15_DIR

CMake will not find these system libraries on non-Windows hosts anyways, and we
were silencing the warnings, so simply omit the installation when
cross-compiling to Windows.