### PR TITLE
Fix cmake warning about CMP0048, again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,11 @@
-cmake_minimum_required(VERSION 2.8.9)
-
-# prevent ugly developer warnings because version is set directly, not through project()
-# it should be redone properly by using VERSION in project() if on CMake 3.x
-if(CMAKE_MAJOR_VERSION GREATER 2)
-    cmake_policy(SET CMP0048 OLD)
-endif()
-
-project(cmark)
+cmake_minimum_required(VERSION 3.0)
+project(cmark VERSION 0.28.3)
 
 include("FindAsan.cmake")
 
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "Do not build in-source.\nPlease remove CMakeCache.txt and the CMakeFiles/ directory.\nThen: mkdir build ; cd build ; cmake .. ; make")
 endif()
-
-set(PROJECT_NAME "cmark")
-
-set(PROJECT_VERSION_MAJOR 0)
-set(PROJECT_VERSION_MINOR 28)
-set(PROJECT_VERSION_PATCH 3)
-set(PROJECT_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH} )
 
 option(CMARK_TESTS "Build cmark tests and enable testing" ON)
 option(CMARK_STATIC "Build static libcmark library" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,7 +59,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmark_version.h.in
 include (GenerateExportHeader)
 
 add_executable(${PROGRAM} ${PROGRAM_SOURCES})
-add_compiler_export_flags()
 
 # Disable the PUBLIC declarations when compiling the executable:
 set_target_properties(${PROGRAM} PROPERTIES
@@ -72,12 +71,9 @@ set(CMAKE_LINKER_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG}")
 set(CMAKE_C_FLAGS_PROFILE "${CMAKE_C_FLAGS_RELEASE} -pg")
 set(CMAKE_LINKER_PROFILE "${CMAKE_LINKER_FLAGS_RELEASE} -pg")
 
-if (${CMAKE_VERSION} VERSION_GREATER "1.8")
-  set(CMAKE_C_VISIBILITY_PRESET hidden)
-  set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
-elseif(CMAKE_COMPILER_IS_GNUCC OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
-endif ()
+# -fvisibility=hidden
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
 if (CMARK_SHARED)
   add_library(${LIBRARY} SHARED ${LIBRARY_SOURCES})


### PR DESCRIPTION
I fixed that warning in #137, by setting the policy to OLD, but now it is being deprecated.

The correct fix is to set it to NEW conditionally and use the `project(.... VERSION)` command which sets all those variables. The old code is kept for compatibility with cmake 2.x.

Given that CMake 3.0 was released in 2014, maybe it is time to set the minimum version to 3.0? This would clean that up.