### PR TITLE
Link executable with static or shared library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,10 +46,7 @@ set(LIBRARY_SOURCES
   )
 
 set(PROGRAM "cmark")
-set(PROGRAM_SOURCES
-  ${LIBRARY_SOURCES}
-  main.c
-  )
+set(PROGRAM_SOURCES main.c)
 
 include_directories(. ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -60,9 +57,14 @@ include (GenerateExportHeader)
 
 add_executable(${PROGRAM} ${PROGRAM_SOURCES})
 
-# Disable the PUBLIC declarations when compiling the executable:
-set_target_properties(${PROGRAM} PROPERTIES
-  COMPILE_FLAGS -DCMARK_STATIC_DEFINE)
+if (CMARK_STATIC)
+  target_link_libraries(${PROGRAM} ${STATICLIBRARY})
+  # Disable the PUBLIC declarations when compiling the executable:
+  set_target_properties(${PROGRAM} PROPERTIES
+    COMPILE_FLAGS -DCMARK_STATIC_DEFINE)
+elseif (CMARK_SHARED)
+  target_link_libraries(${PROGRAM} ${LIBRARY})
+endif()
 
 # Check integrity of node structure when compiled as debug:
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DCMARK_DEBUG_NODES")


### PR DESCRIPTION
If CMARK_STATIC is on (default), link the executable with the static
library. This produces exactly the same result as compiling the library
sources again and linking with the object files.

If CMARK_STATIC is off, link the executable with the shared library.
This wasn't supported before and should be the preferred way to
package cmark on Linux distros.

Building only a shared library and a statically linked executable
isn't supported anymore but this doesn't seem useful.