### PR TITLE
Fix source positions for inlines.

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -889,68 +889,170 @@ static void test_feed_across_line_ending(test_batch_runner *runner) {
 }
 
 static void source_pos(test_batch_runner *runner) {
-  static const char markdown[] =
-    "# Hi *there*.\n"
-    "\n"
-    "Hello &ldquo; <http://www.google.com>\n"
-    "there `hi` -- [okay](www.google.com (ok)).\n"
-    "\n"
-    "> 1. Okay.\n"
-    ">    Sure.\n"
-    ">\n"
-    "> 2. Yes, okay.\n"
-    ">    ![ok](hi \"yes\")\n";
+  {
+    static const char markdown[] =
+      "# Hi *there*.\n"
+      "\n"
+      "Hello &ldquo; <http://www.google.com>\n"
+      "there `hi` -- [okay](www.google.com (ok)).\n"
+      "\n"
+      "> 1. Okay.\n"
+      ">    Sure.\n"
+      ">\n"
+      "> 2. Yes, okay.\n"
+      ">    ![ok](hi \"yes\")\n";
 
-  cmark_node *doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
-  char *xml = cmark_render_xml(doc, CMARK_OPT_DEFAULT | CMARK_OPT_SOURCEPOS);
-  STR_EQ(runner, xml, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                      "<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n"
-                      "<document sourcepos=\"1:1-10:20\" xmlns=\"http://commonmark.org/xml/1.0\">\n"
-                      "  <heading sourcepos=\"1:1-1:13\" level=\"1\">\n"
-                      "    <text sourcepos=\"1:3-1:5\" xml:space=\"preserve\">Hi </text>\n"
-                      "    <emph sourcepos=\"1:6-1:12\">\n"
-                      "      <text sourcepos=\"1:7-1:11\" xml:space=\"preserve\">there</text>\n"
-                      "    </emph>\n"
-                      "    <text sourcepos=\"1:13-1:13\" xml:space=\"preserve\">.</text>\n"
-                      "  </heading>\n"
-                      "  <paragraph sourcepos=\"3:1-4:42\">\n"
-                      "    <text sourcepos=\"3:1-3:14\" xml:space=\"preserve\">Hello “ </text>\n"
-                      "    <link sourcepos=\"3:15-3:37\" destination=\"http://www.google.com\" title=\"\">\n"
-                      "      <text sourcepos=\"3:16-3:36\" xml:space=\"preserve\">http://www.google.com</text>\n"
-                      "    </link>\n"
-                      "    <softbreak />\n"
-                      "    <text sourcepos=\"4:1-4:6\" xml:space=\"preserve\">there </text>\n"
-                      "    <code sourcepos=\"4:8-4:9\" xml:space=\"preserve\">hi</code>\n"
-                      "    <text sourcepos=\"4:11-4:14\" xml:space=\"preserve\"> -- </text>\n"
-                      "    <link sourcepos=\"4:15-4:41\" destination=\"www.google.com\" title=\"ok\">\n"
-                      "      <text sourcepos=\"4:16-4:19\" xml:space=\"preserve\">okay</text>\n"
-                      "    </link>\n"
-                      "    <text sourcepos=\"4:42-4:42\" xml:space=\"preserve\">.</text>\n"
-                      "  </paragraph>\n"
-                      "  <block_quote sourcepos=\"6:1-10:20\">\n"
-                      "    <list sourcepos=\"6:3-10:20\" type=\"ordered\" start=\"1\" delim=\"period\" tight=\"false\">\n"
-                      "      <item sourcepos=\"6:3-8:1\">\n"
-                      "        <paragraph sourcepos=\"6:6-7:10\">\n"
-                      "          <text sourcepos=\"6:6-6:10\" xml:space=\"preserve\">Okay.</text>\n"
-                      "          <softbreak />\n"
-                      "          <text sourcepos=\"7:6-7:10\" xml:space=\"preserve\">Sure.</text>\n"
-                      "        </paragraph>\n"
-                      "      </item>\n"
-                      "      <item sourcepos=\"9:3-10:20\">\n"
-                      "        <paragraph sourcepos=\"9:6-10:20\">\n"
-                      "          <text sourcepos=\"9:6-9:15\" xml:space=\"preserve\">Yes, okay.</text>\n"
-                      "          <softbreak />\n"
-                      "          <image sourcepos=\"10:6-10:20\" destination=\"hi\" title=\"yes\">\n"
-                      "            <text sourcepos=\"10:8-10:9\" xml:space=\"preserve\">ok</text>\n"
-                      "          </image>\n"
-                      "        </paragraph>\n"
-                      "      </item>\n"
-                      "    </list>\n"
-                      "  </block_quote>\n"
-                      "</document>\n",
-         "sourcepos are as expected");
-  free(xml);
-  cmark_node_free(doc);
+    cmark_node *doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
+    char *xml = cmark_render_xml(doc, CMARK_OPT_DEFAULT | CMARK_OPT_SOURCEPOS);
+    STR_EQ(runner, xml, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        "<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n"
+                        "<document sourcepos=\"1:1-10:20\" xmlns=\"http://commonmark.org/xml/1.0\">\n"
+                        "  <heading sourcepos=\"1:1-1:13\" level=\"1\">\n"
+                        "    <text sourcepos=\"1:3-1:5\" xml:space=\"preserve\">Hi </text>\n"
+                        "    <emph sourcepos=\"1:6-1:12\">\n"
+                        "      <text sourcepos=\"1:7-1:11\" xml:space=\"preserve\">there</text>\n"
+                        "    </emph>\n"
+                        "    <text sourcepos=\"1:13-1:13\" xml:space=\"preserve\">.</text>\n"
+                        "  </heading>\n"
+                        "  <paragraph sourcepos=\"3:1-4:42\">\n"
+                        "    <text sourcepos=\"3:1-3:14\" xml:space=\"preserve\">Hello \xe2\x80\x9c </text>\n"
+                        "    <link sourcepos=\"3:15-3:37\" destination=\"http://www.google.com\" title=\"\">\n"
+                        "      <text sourcepos=\"3:16-3:36\" xml:space=\"preserve\">http://www.google.com</text>\n"
+                        "    </link>\n"
+                        "    <softbreak />\n"
+                        "    <text sourcepos=\"4:1-4:6\" xml:space=\"preserve\">there </text>\n"
+                        "    <code sourcepos=\"4:8-4:9\" xml:space=\"preserve\">hi</code>\n"
+                        "    <text sourcepos=\"4:11-4:14\" xml:space=\"preserve\"> -- </text>\n"
+                        "    <link sourcepos=\"4:15-4:41\" destination=\"www.google.com\" title=\"ok\">\n"
+                        "      <text sourcepos=\"4:16-4:19\" xml:space=\"preserve\">okay</text>\n"
+                        "    </link>\n"
+                        "    <text sourcepos=\"4:42-4:42\" xml:space=\"preserve\">.</text>\n"
+                        "  </paragraph>\n"
+                        "  <block_quote sourcepos=\"6:1-10:20\">\n"
+                        "    <list sourcepos=\"6:3-10:20\" type=\"ordered\" start=\"1\" delim=\"period\" tight=\"false\">\n"
+                        "      <item sourcepos=\"6:3-8:1\">\n"
+                        "        <paragraph sourcepos=\"6:6-7:10\">\n"
+                        "          <text sourcepos=\"6:6-6:10\" xml:space=\"preserve\">Okay.</text>\n"
+                        "          <softbreak />\n"
+                        "          <text sourcepos=\"7:6-7:10\" xml:space=\"preserve\">Sure.</text>\n"
+                        "        </paragraph>\n"
+                        "      </item>\n"
+                        "      <item sourcepos=\"9:3-10:20\">\n"
+                        "        <paragraph sourcepos=\"9:6-10:20\">\n"
+                        "          <text sourcepos=\"9:6-9:15\" xml:space=\"preserve\">Yes, okay.</text>\n"
+                        "          <softbreak />\n"
+                        "          <image sourcepos=\"10:6-10:20\" destination=\"hi\" title=\"yes\">\n"
+                        "            <text sourcepos=\"10:8-10:9\" xml:space=\"preserve\">ok</text>\n"
+                        "          </image>\n"
+                        "        </paragraph>\n"
+                        "      </item>\n"
+                        "    </list>\n"
+                        "  </block_quote>\n"
+                        "</document>\n",
+           "sourcepos are as expected");
+    free(xml);
+    cmark_node_free(doc);
+  }
+  {
+    static const char markdown[] =
+    "1.  **Start condition:**  line begins with the string `<script`,\n"
+    "     `<pre`, or `<style` (case-insensitive), followed by whitespace,\n"
+    "the string `>`, or the end of the line.\\\n"
+    "    **End condition:**  line contains an end tag\n"
+    "  `</script>`, `</pre>`, or `</style>` (case-insensitive; it\n"
+    "   need not match the start tag).\n";
+
+    cmark_node *doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
+    char *xml = cmark_render_xml(doc, CMARK_OPT_DEFAULT | CMARK_OPT_SOURCEPOS);
+    STR_EQ(runner, xml, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+           "<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n"
+           "<document sourcepos=\"1:1-6:33\" xmlns=\"http://commonmark.org/xml/1.0\">\n"
+           "  <list sourcepos=\"1:1-6:33\" type=\"ordered\" start=\"1\" delim=\"period\" tight=\"true\">\n"
+           "    <item sourcepos=\"1:1-6:33\">\n"
+           "      <paragraph sourcepos=\"1:5-6:33\">\n"
+           "        <strong sourcepos=\"1:5-1:24\">\n"
+           "          <text sourcepos=\"1:7-1:22\" xml:space=\"preserve\">Start condition:</text>\n"
+           "        </strong>\n"
+           "        <text sourcepos=\"1:25-1:54\" xml:space=\"preserve\">  line begins with the string </text>\n"
+           "        <code sourcepos=\"1:56-1:62\" xml:space=\"preserve\">&lt;script</code>\n"
+           "        <text sourcepos=\"1:64-1:64\" xml:space=\"preserve\">,</text>\n"
+           "        <softbreak />\n"
+           "        <code sourcepos=\"2:7-2:10\" xml:space=\"preserve\">&lt;pre</code>\n"
+           "        <text sourcepos=\"2:12-2:16\" xml:space=\"preserve\">, or </text>\n"
+           "        <code sourcepos=\"2:18-2:23\" xml:space=\"preserve\">&lt;style</code>\n"
+           "        <text sourcepos=\"2:25-2:68\" xml:space=\"preserve\"> (case-insensitive), followed by whitespace,</text>\n"
+           "        <softbreak />\n"
+           "        <text sourcepos=\"3:1-3:11\" xml:space=\"preserve\">the string </text>\n"
+           "        <code sourcepos=\"3:13-3:13\" xml:space=\"preserve\">&gt;</code>\n"
+           "        <text sourcepos=\"3:15-3:39\" xml:space=\"preserve\">, or the end of the line.</text>\n"
+           "        <linebreak />\n"
+           "        <strong sourcepos=\"4:5-4:22\">\n"
+           "          <text sourcepos=\"4:7-4:20\" xml:space=\"preserve\">End condition:</text>\n"
+           "        </strong>\n"
+           "        <text sourcepos=\"4:23-4:48\" xml:space=\"preserve\">  line contains an end tag</text>\n"
+           "        <softbreak />\n"
+           "        <code sourcepos=\"5:4-5:12\" xml:space=\"preserve\">&lt;/script&gt;</code>\n"
+           "        <text sourcepos=\"5:14-5:15\" xml:space=\"preserve\">, </text>\n"
+           "        <code sourcepos=\"5:17-5:22\" xml:space=\"preserve\">&lt;/pre&gt;</code>\n"
+           "        <text sourcepos=\"5:24-5:28\" xml:space=\"preserve\">, or </text>\n"
+           "        <code sourcepos=\"5:30-5:37\" xml:space=\"preserve\">&lt;/style&gt;</code>\n"
+           "        <text sourcepos=\"5:39-5:60\" xml:space=\"preserve\"> (case-insensitive; it</text>\n"
+           "        <softbreak />\n"
+           "        <text sourcepos=\"6:4-6:33\" xml:space=\"preserve\">need not match the start tag).</text>\n"
+           "      </paragraph>\n"
+           "    </item>\n"
+           "  </list>\n"
+           "</document>\n",
+           "list (with EOL backslash) sourcepos are as expected");
+    free(xml);
+    cmark_node_free(doc);
+  }
+  {
+    static const char markdown[] =
+    "> The overriding design goal for Markdown's formatting syntax is\n"
+    "  > to make it as **readable as possible**. The idea is that a\n"
+    "> Markdown-formatted document should be publishable as-is, as\n"
+    "  > plain text, without *looking like* it's been marked up with tags\n"
+    " > or formatting instructions.\n"
+    "> (<http://daringfireball.net/projects/markdown/>)\n";
+
+    cmark_node *doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
+    char *xml = cmark_render_xml(doc, CMARK_OPT_DEFAULT | CMARK_OPT_SOURCEPOS);
+    STR_EQ(runner, xml, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+           "<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n"
+           "<document sourcepos=\"1:1-6:50\" xmlns=\"http://commonmark.org/xml/1.0\">\n"
+           "  <block_quote sourcepos=\"1:1-6:50\">\n"
+           "    <paragraph sourcepos=\"1:3-6:50\">\n"
+           "      <text sourcepos=\"1:3-1:64\" xml:space=\"preserve\">The overriding design goal for Markdown's formatting syntax is</text>\n"
+           "      <softbreak />\n"
+           "      <text sourcepos=\"2:5-2:18\" xml:space=\"preserve\">to make it as </text>\n"
+           "      <strong sourcepos=\"2:19-2:42\">\n"
+           "        <text sourcepos=\"2:21-2:40\" xml:space=\"preserve\">readable as possible</text>\n"
+           "      </strong>\n"
+           "      <text sourcepos=\"2:43-2:62\" xml:space=\"preserve\">. The idea is that a</text>\n"
+           "      <softbreak />\n"
+           "      <text sourcepos=\"3:3-3:61\" xml:space=\"preserve\">Markdown-formatted document should be publishable as-is, as</text>\n"
+           "      <softbreak />\n"
+           "      <text sourcepos=\"4:5-4:24\" xml:space=\"preserve\">plain text, without </text>\n"
+           "      <emph sourcepos=\"4:25-4:38\">\n"
+           "        <text sourcepos=\"4:26-4:37\" xml:space=\"preserve\">looking like</text>\n"
+           "      </emph>\n"
+           "      <text sourcepos=\"4:39-4:68\" xml:space=\"preserve\"> it's been marked up with tags</text>\n"
+           "      <softbreak />\n"
+           "      <text sourcepos=\"5:4-5:30\" xml:space=\"preserve\">or formatting instructions.</text>\n"
+           "      <softbreak />\n"
+           "      <text sourcepos=\"6:3-6:3\" xml:space=\"preserve\">(</text>\n"
+           "      <link sourcepos=\"6:4-6:49\" destination=\"http://daringfireball.net/projects/markdown/\" title=\"\">\n"
+           "        <text sourcepos=\"6:-283-6:-240\" xml:space=\"preserve\">http://daringfireball.net/projects/markdown/</text>\n"
+           "      </link>\n"
+           "      <text sourcepos=\"6:50-6:50\" xml:space=\"preserve\">)</text>\n"
+           "    </paragraph>\n"
+           "  </block_quote>\n"
+           "</document>\n",
+           "inconsistently indented blockquote sourcepos are as expected");
+    free(xml);
+    cmark_node_free(doc);
+  }
 }
 
 static void source_pos_inlines(test_batch_runner *runner) {
@@ -995,6 +1097,33 @@ static void source_pos_inlines(test_batch_runner *runner) {
                         "  </paragraph>\n"
                         "</document>\n",
                         "sourcepos are as expected");
+    free(xml);
+    cmark_node_free(doc);
+  }
+  {
+    static const char markdown[] =
+    "This link will have two [soft \n"
+    "line\n"
+    " breaks](https://commonmark.org).";
+
+    cmark_node *doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
+    char *xml = cmark_render_xml(doc, CMARK_OPT_DEFAULT | CMARK_OPT_SOURCEPOS);
+    STR_EQ(runner, xml, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+           "<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n"
+           "<document sourcepos=\"1:1-3:33\" xmlns=\"http://commonmark.org/xml/1.0\">\n"
+           "  <paragraph sourcepos=\"1:1-3:33\">\n"
+           "    <text sourcepos=\"1:1-1:26\" xml:space=\"preserve\">This link will have three </text>\n"
+           "    <link sourcepos=\"1:27-3:32\" destination=\"https://commonmark.org\" title=\"\">\n"
+           "      <text sourcepos=\"1:28-1:32\" xml:space=\"preserve\">soft</text>\n"
+           "      <softbreak />\n"
+           "      <text sourcepos=\"2:1-2:4\" xml:space=\"preserve\">line</text>\n"
+           "      <softbreak />\n"
+           "      <text sourcepos=\"3:2-3:7\" xml:space=\"preserve\">breaks</text>\n"
+           "    </link>\n"
+           "    <text sourcepos=\"3:33-3:33\" xml:space=\"preserve\">.</text>\n"
+           "  </paragraph>\n"
+           "</document>\n",
+           "autolink sourcepos are as expected");
     free(xml);
     cmark_node_free(doc);
   }

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -242,6 +242,11 @@ void cmark_strbuf_trim(cmark_strbuf *buf) {
   cmark_strbuf_rtrim(buf);
 }
 
+void cmark_strbuf_remove(cmark_strbuf *buf, bufsize_t start_offset, bufsize_t len) {
+  memmove(buf->ptr + start_offset, buf->ptr + start_offset + len, buf->size - (start_offset + len));
+  buf->size -= len;
+}
+
 // Destructively modify string, collapsing consecutive
 // space and newline characters into a single space.
 void cmark_strbuf_normalize_whitespace(cmark_strbuf *s) {

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -72,6 +72,15 @@ void cmark_strbuf_drop(cmark_strbuf *buf, bufsize_t n);
 void cmark_strbuf_truncate(cmark_strbuf *buf, bufsize_t len);
 void cmark_strbuf_rtrim(cmark_strbuf *buf);
 void cmark_strbuf_trim(cmark_strbuf *buf);
+
+/**
+ Removes the characters in the given range.
+
+ @param buf The string buffer.
+ @param start_offset The starting character offset.
+ @param len The length of characters to remove.
+ */
+void cmark_strbuf_remove(cmark_strbuf *buf, bufsize_t start_offset, bufsize_t len);
 void cmark_strbuf_normalize_whitespace(cmark_strbuf *s);
 void cmark_strbuf_unescape(cmark_strbuf *s);
 

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -327,10 +327,10 @@ static bufsize_t scan_to_closing_backticks(subject *subj,
 // spaces, then removing a single leading + trailing space,
 // unless the code span consists entirely of space characters.
 static void S_normalize_code(cmark_strbuf *s) {
-  bufsize_t r, w;
+  bufsize_t r, w, last_char_after_nl;
   bool contains_nonspace = false;
 
-  for (r = 0, w = 0; r < s->size; ++r) {
+  for (r = 0, w = 0, last_char_after_nl = 0; r < s->size; ++r) {
     switch (s->ptr[r]) {
     case '\r':
       if (s->ptr[r + 1] != '\n') {
@@ -339,13 +339,44 @@ static void S_normalize_code(cmark_strbuf *s) {
       break;
     case '\n':
       s->ptr[w++] = ' ';
+      last_char_after_nl = w;
+      break;
+    case ' ':
+      s->ptr[w++] = s->ptr[r];
       break;
     default:
+      if (last_char_after_nl) {
+        // Remove leading whitespace.
+        bufsize_t remove_len = r - last_char_after_nl;
+
+        if (remove_len) {
+          cmark_strbuf_remove(s, last_char_after_nl, remove_len);
+          w -= remove_len;
+          r -= remove_len;
+        }
+
+        last_char_after_nl = 0;
+      }
+
       s->ptr[w++] = s->ptr[r];
     }
     if (s->ptr[r] != ' ') {
       contains_nonspace = true;
     }
+  }
+
+  if (last_char_after_nl) {
+    // Remove leading whitespace. Only reach here if the closing backquote
+    // delimiter is on its own line.
+    bufsize_t remove_len = r - last_char_after_nl;
+
+    if (remove_len) {
+      cmark_strbuf_remove(s, last_char_after_nl, remove_len);
+      w -= remove_len;
+      r -= remove_len;
+    }
+
+    last_char_after_nl = 0;
   }
 
   // begins and ends with space?
@@ -363,13 +394,15 @@ static void S_normalize_code(cmark_strbuf *s) {
 // Parse backtick code section or raw backticks, return an inline.
 // Assumes that the subject has a backtick at the current position.
 static cmark_node *handle_backticks(subject *subj, int options) {
+  // Save the current source position in case of need to rewind.
+  bufsize_t subjpos = subj->pos;
   cmark_chunk openticks = take_while(subj, isbacktick);
   bufsize_t startpos = subj->pos;
   bufsize_t endpos = scan_to_closing_backticks(subj, openticks.len);
 
   if (endpos == 0) {      // not found
     subj->pos = startpos; // rewind
-    return make_str(subj, subj->pos, subj->pos, openticks);
+    return make_str(subj, subjpos, subjpos, openticks);
   } else {
     cmark_strbuf buf = CMARK_BUF_INIT(subj->mem);
 
@@ -772,6 +805,10 @@ static cmark_node *handle_backslash(subject *subj) {
     advance(subj);
     return make_str(subj, subj->pos - 2, subj->pos - 1, cmark_chunk_dup(&subj->input, subj->pos - 1, 1));
   } else if (!is_eof(subj) && skip_line_end(subj)) {
+    // Adjust the subject source position state.
+    ++subj->line;
+    subj->column_offset = -subj->pos;
+
     return make_linebreak(subj->mem);
   } else {
     return make_str(subj, subj->pos - 1, subj->pos - 1, cmark_chunk_literal("\\"));
@@ -852,7 +889,8 @@ static cmark_node *handle_pointy_brace(subject *subj, int options) {
     contents = cmark_chunk_dup(&subj->input, subj->pos, matchlen - 1);
     subj->pos += matchlen;
 
-    return make_autolink(subj, subj->pos - 1 - matchlen, subj->pos - 1, contents, 0);
+    return make_autolink(subj, subj->pos + subj->column_offset - 1 - matchlen,
+                         subj->pos + subj->column_offset - 1, contents, 0);
   }
 
   // next try to match an email autolink
@@ -861,7 +899,8 @@ static cmark_node *handle_pointy_brace(subject *subj, int options) {
     contents = cmark_chunk_dup(&subj->input, subj->pos, matchlen - 1);
     subj->pos += matchlen;
 
-    return make_autolink(subj, subj->pos - 1 - matchlen, subj->pos - 1, contents, 1);
+    return make_autolink(subj, subj->pos + subj->column_offset - 1 - matchlen,
+                         subj->pos + subj->column_offset - 1, contents, 1);
   }
 
   // finally, try to match an html tag
@@ -1106,7 +1145,8 @@ match:
   inl = make_simple(subj->mem, is_image ? CMARK_NODE_IMAGE : CMARK_NODE_LINK);
   inl->as.link.url = url;
   inl->as.link.title = title;
-  inl->start_line = inl->end_line = subj->line;
+  inl->start_line = opener->inl_text->start_line;
+  inl->end_line = subj->line;
   inl->start_column = opener->inl_text->start_column;
   inl->end_column = subj->pos + subj->column_offset + subj->block_offset;
   cmark_node_insert_before(opener->inl_text, inl);
@@ -1217,10 +1257,21 @@ static int parse_inline(subject *subj, cmark_node *parent, int options) {
   cmark_chunk contents;
   unsigned char c;
   bufsize_t startpos, endpos;
+  int saved_block_offset = subj->block_offset;
+
   c = peek_char(subj);
   if (c == 0) {
     return 0;
   }
+
+  // If NOT the subject's initial line...
+  if (subj->column_offset != 0) {
+    // Reset the block offset. The line's leading trivia was not trimmed,
+    // so the source position will be computed appropriately without the
+    // block offset.
+    subj->block_offset = 0;
+  }
+
   switch (c) {
   case '\r':
   case '\n':
@@ -1279,11 +1330,26 @@ static int parse_inline(subject *subj, cmark_node *parent, int options) {
       cmark_chunk_rtrim(&contents);
     }
 
+    // If not the initial line (in the subject) AND at the beginning of another line.
+    if (subj->column_offset != 0 && startpos + subj->column_offset == 0) {
+      // Trim leading whitespace.
+      bufsize_t before_trim = contents.len;
+      cmark_chunk_ltrim(&contents);
+
+      if (contents.len == 0)
+        break; // The contents were only whitespaces.
+
+      // Update the start source position.
+      startpos += before_trim - contents.len;
+    }
+
     new_inl = make_str(subj, startpos, endpos - 1, contents);
   }
   if (new_inl != NULL) {
     cmark_node_append_child(parent, new_inl);
   }
+
+  subj->block_offset = saved_block_offset;
 
   return 1;
 }


### PR DESCRIPTION
This PR fixes the source positions for:

 * Inlines inside inconsistently indented blocks.
 * Links/images.
 * Autolinks.
 * Escaped newlines.
 * Non-matched backticks.

Fixing the source positions for inlines inside inconsistently indented blocks is accomplished by maintaining the leading trivia when constructing the block (see `add_line` in *blocks.c*), and removing it during the inline parsing stage (see changes in *inlines.c*). The three source position tests added demonstrate the current implementation's shortfalls.

These changes are minimally invasive, and thus, slightly degrade performance—due to stripping the leading whitespace during the inline parsing phase. This can be avoided for normal parse/render operations by wrapping the functionality introduced in this PR with the conditional `if (CMARK_OPT_SOURCEPOS & options)`. However, this will lead to the output of invalid source positions when the `CMARK_OPT_SOURCEPOS` option is specified for a rendering operation (i.e. `cmark_render_xml`) but not the original parsing operation (i.e. `cmark_parse_document`).