### PR TITLE
Clarify which backtick strings

### DIFF
--- a/test/spec.txt
+++ b/test/spec.txt
@@ -5854,7 +5854,7 @@ preceded nor followed by a backtick.
 
 A [code span](@) begins with a backtick string and ends with
 a backtick string of equal length.  The contents of the code span are
-the characters between the two backtick strings, normalized in the
+the characters between these two backtick strings, normalized in the
 following ways:
 
 - First, [line endings] are converted to [spaces].


### PR DESCRIPTION
A code span can have more than its two surrounding ones, like ` `` `.