### PR TITLE
fix -Wconst-qual warning

### DIFF
--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -179,7 +179,7 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
   char fencechar[2] = {'\0', '\0'};
   size_t info_len, code_len;
   char listmarker[LISTMARKER_SIZE];
-  char *emph_delim;
+  const char *emph_delim;
   bool first_in_list_item;
   bufsize_t marker_width;
   bool has_nonspace;


### PR DESCRIPTION
The string literal being assigned is const, but the assignment looses
the constness of this string.  This enables building with `/Zc:strictString`
with MSVC as well.