### PR TITLE
build: use absolute path for cmarkTargets.cmake

### DIFF
--- a/src/cmarkConfig.cmake.in
+++ b/src/cmarkConfig.cmake.in
@@ -3,5 +3,5 @@ set(HAVE_LIBCMARK_SHARED @CMARK_SHARED@)
 
 if((HAVE_LIBCMARK_STATIC AND NOT TARGET libcmark_static) OR
    (HAVE_LIBCMARK_SHARED AND NOT TARGET libcmark))
-  include(cmarkTargets.cmake)
+   include(${CMAKE_CURRENT_LIST_DIR}/cmarkTargets.cmake)
 endif()


### PR DESCRIPTION
Adjust the include of the CMake file to use a cmarkConfig.cmake relative
location which enables use without considerations for the path.