### PR TITLE
build: substitute the path into the generate files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,9 +141,10 @@ if(CMARK_SHARED OR CMARK_STATIC)
 
   install(EXPORT cmark DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 
+  set(CMARK_TARGETS_FILE ${CMAKE_CURRENT_BINARY_DIR}/cmarkTargets.cmake)
   configure_file(cmarkConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/cmarkConfig.cmake)
-  export(TARGETS ${CMARK_INSTALL} FILE cmarkTargets.cmake)
+  export(TARGETS ${CMARK_INSTALL} FILE ${CMARK_TARGETS_FILE})
 endif()
 
 # Feature tests

--- a/src/cmarkConfig.cmake.in
+++ b/src/cmarkConfig.cmake.in
@@ -3,5 +3,5 @@ set(HAVE_LIBCMARK_SHARED @CMARK_SHARED@)
 
 if((HAVE_LIBCMARK_STATIC AND NOT TARGET libcmark_static) OR
    (HAVE_LIBCMARK_SHARED AND NOT TARGET libcmark))
-   include(${CMAKE_CURRENT_LIST_DIR}/cmarkTargets.cmake)
+   include(@CMARK_TARGETS_FILE@)
 endif()


### PR DESCRIPTION
This resorts to the variable substitution to ensure the path embedded is
correct.  Without this, the path at the time of the configuration.  In
the case of the Swift project, this ended up searching in the *source*
directory rather than the *build* directory.  This will ensure that we
export the file to an absolute location and we use the same location in
the `cmarkConfig.cmake` file by means of CMake's `configure_file`
subsitution.