### PR TITLE
Provide a CMARK_UNSAFE environment variable for backwards compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,20 @@ Security
 
 By default, the library will scrub raw HTML and potentially
 dangerous links (`javascript:`, `vbscript:`, `data:`, `file:`).
+This behaviour change was introduced in the 0.29.0 release.
 
-To allow these, use the option `CMARK_OPT_UNSAFE` (or
-`--unsafe`) with the command line program. If doing so, we
-recommend you use a HTML sanitizer specific to your needs to
-protect against [XSS
-attacks](http://en.wikipedia.org/wiki/Cross-site_scripting).
+In the API, you can use the option `CMARK_OPT_UNSAFE` to disable it.
+
+When calling the `cmark` command line program, you can disable it
+with `--unsafe` option.
+
+You can also disable it by setting the `CMARK_UNSAFE` environment variable.
+If you want a script to work with both older and newer versions,
+you can use `CMARK_UNSAFE=1 cmark` command.
+
+If your Markdown files come from an untrusted source,
+we recommend that you use an HTML sanitizer
+to prevent [XSS attacks](http://en.wikipedia.org/wiki/Cross-site_scripting).
 
 Contributing
 ------------

--- a/src/main.c
+++ b/src/main.c
@@ -161,6 +161,11 @@ int main(int argc, char *argv[]) {
     }
   }
 
+  char* unsafe_env_var = getenv("CMARK_UNSAFE");
+  if (unsafe_env_var != NULL) {
+    options |= CMARK_OPT_UNSAFE;
+  }
+
   parser = cmark_parser_new(options);
   for (i = 0; i < numfps; i++) {
     FILE *fp = fopen(argv[files[i]], "rb");


### PR DESCRIPTION
Making safe mode the default is a noble idea. However, an incompatible change without a backwards compatibility option, after years of unchanging behaviour, is a serious headache.

cmark 0.28 is still in a lot of still supported OSes/distros. If you use cmark as a part of a build process and your Markdown comes from a trusted/reviewed source, you have to choose between old and new because the old one will complain about an invalid option if you run `cmark --unsafe`, and the new one will auto-escape HTML without it.

Environment variables can be an effective backwards compatibility mechanism: for the new versions it will disable safe mode, and for old versions it will have no ill effects.

This patch adds `CMARK_UNSAFE` environment variable in addition to the `--unsafe` option, with the same effect.

```
$ ./build/src/cmark 
<blink>hello world</blink> ^D

<p><!-- raw HTML omitted -->hello world<!-- raw HTML omitted --></p>

$ CMARK_UNSAFE=1 ./build/src/cmark 
<blink>hello world</blink> ^D

<p><blink>hello world</blink></p>
```

I'm open to discussion regarding the naming and implementation.