### PR TITLE
Adjust the MinGW paths for MinGW64 to enable cross-compiling on post-2014 systems

### DIFF
--- a/toolchain-mingw32.cmake
+++ b/toolchain-mingw32.cmake
@@ -2,15 +2,15 @@
 SET(CMAKE_SYSTEM_NAME Windows)
 
 # which compilers to use for C and C++
-SET(CMAKE_C_COMPILER i586-mingw32msvc-gcc)
-SET(CMAKE_CXX_COMPILER i586-mingw32msvc-g++)
-SET(CMAKE_RC_COMPILER i586-mingw32msvc-windres)
+SET(CMAKE_C_COMPILER i686-w64-mingw32-gcc)
+SET(CMAKE_CXX_COMPILER i686-w64-mingw32-g++)
+SET(CMAKE_RC_COMPILER i686-w64-mingw32-windres)
 
 # here is the target environment located
-SET(CMAKE_FIND_ROOT_PATH  /usr/i586-mingw32msvc "${CMAKE_SOURCE_DIR}/windows")
+SET(CMAKE_FIND_ROOT_PATH /usr/i686-w64-mingw32/ "${CMAKE_SOURCE_DIR}/windows")
 
 # adjust the default behaviour of the FIND_XXX() commands:
-# search headers and libraries in the target environment, search 
+# search headers and libraries in the target environment, search
 # programs in the host environment
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
The CMake file for cross-compiling has a hardcoded assumption that the host has classic MinGW.

The original MinGW is now essentially dead. All GNU/Linux distros have switches to a fork named MinGW64 ([[1]](http://mingw-w64.org/), [[2]](https://en.wikipedia.org/wiki/Mingw-w64)).
Debian has been using it since Jessie (2015) for example.
Despite it's name it's not Win64-only, it supports both Win32 and Win64, unlike original MinGW that was Win-32only.

This makes the original file useless on modern systems, it needs path adjustments.

I have only tested this patch on Fedora and Debian, but I assume in other distros paths are the same.

```
$ make mingw 
mkdir -p build-mingw; \
cd build-mingw; \
cmake .. -DCMAKE_TOOLCHAIN_FILE=../toolchain-mingw32.cmake -DCMAKE_INSTALL_PREFIX=windows ;\
make && make install
-- The CXX compiler identification is GNU 9.2.1
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++
-- Check for working CXX compiler: /usr/bin/i686-w64-mingw32-g++ - works
[SNIP]
make[1]: Leaving directory '/home/dmbaturin/devel/cmark/build-mingw'

$ file build-mingw/src/cmark.exe 
build-mingw/src/cmark.exe: PE32 executable (console) Intel 80386, for MS Windows

$ wine build-mingw/src/cmark.exe --version
cmark 0.29.0 - CommonMark converter
(C) 2014-2016 John MacFarlane
```