### PR TITLE
Avoid quadratic output growth with reference links

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <limits.h>
 
 #include "cmark_ctype.h"
 #include "config.h"
@@ -518,6 +519,14 @@ static cmark_node *finalize_document(cmark_parser *parser) {
   }
 
   finalize(parser, parser->root);
+
+  // Limit total size of extra content created from reference links to
+  // document size to avoid superlinear growth. Always allow 100KB.
+  if (parser->total_size > 100000)
+    parser->refmap->max_ref_size = parser->total_size;
+  else
+    parser->refmap->max_ref_size = 100000;
+
   process_inlines(parser->mem, parser->root, parser->refmap, parser->options);
 
   cmark_strbuf_free(&parser->content);
@@ -563,6 +572,11 @@ static void S_parser_feed(cmark_parser *parser, const unsigned char *buffer,
                           size_t len, bool eof) {
   const unsigned char *end = buffer + len;
   static const uint8_t repl[] = {239, 191, 189};
+
+  if (len > UINT_MAX - parser->total_size)
+    parser->total_size = UINT_MAX;
+  else
+    parser->total_size += len;
 
   // Skip UTF-8 BOM if present; see #334
   if (parser->line_number == 0 && parser->column == 0 && len >= 3 &&

--- a/src/parser.h
+++ b/src/parser.h
@@ -32,6 +32,7 @@ struct cmark_parser {
   cmark_strbuf content;
   int options;
   bool last_buffer_ended_with_cr;
+  unsigned int total_size;
 };
 
 #ifdef __cplusplus

--- a/src/references.h
+++ b/src/references.h
@@ -13,6 +13,7 @@ struct cmark_reference {
   unsigned char *url;
   unsigned char *title;
   unsigned int age;
+  unsigned int size;
 };
 
 typedef struct cmark_reference cmark_reference;
@@ -22,6 +23,8 @@ struct cmark_reference_map {
   cmark_reference *refs;
   cmark_reference **sorted;
   unsigned int size;
+  unsigned int ref_size;
+  unsigned int max_ref_size;
 };
 
 typedef struct cmark_reference_map cmark_reference_map;


### PR DESCRIPTION
Keep track of the number bytes added through expansion of reference
links and limit the total to the size of the input document. Always
allow a minimum of 100KB.

Unfortunately, cmark has no error handling, so all we can do is to
stop expanding reference links without returning an error. This should
never be an issue in practice though. The 100KB minimum alone should
cover all real-world cases.

See issue #354.