### PR TITLE
docs: fix simple typo, chacters -> characters

### DIFF
--- a/src/houdini_href_e.c
+++ b/src/houdini_href_e.c
@@ -20,7 +20,7 @@
  * have its native function (i.e. as an URL
  * component/separator) and hence needs no escaping.
  *
- * There are two exceptions: the chacters & (amp)
+ * There are two exceptions: the characters & (amp)
  * and ' (single quote) do not appear in the table.
  * They are meant to appear in the URL as components,
  * yet they require special HTML-entity escaping


### PR DESCRIPTION
There is a small typo in src/houdini_href_e.c.

Should read `characters` rather than `chacters`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md