### PR TITLE
Remove unnecessary comment in output

### DIFF
--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -218,7 +218,6 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       // this ensures that a following indented code block or list will be
       // inteprereted correctly.
       CR();
-      LIT("<!-- end list -->");
       BLANKLINE();
     }
     break;


### PR DESCRIPTION
When calling the `cmark_render_commonmark` with a cmark_node*, which converts the AST to markdown text again, it should just give me the barebone markdown format, without _unnecessary_ comments.

This is the only comment I could find in the output.

Regards,

Melroy van den Berg

