### PR TITLE
build: allow building with CMake[<3.3]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,33 +28,34 @@ if(CMARK_STATIC AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
 endif()
 
-# Compiler flags
-if(MSVC)
-  # Force to always compile with W4
-  add_compile_options($<$<COMPILE_LANGUAGE:C>:/W4>)
-  add_compile_options($<$<COMPILE_LANGUAGE:C>:/wd4706>)
-  # Compile as C++ under MSVC older than 12.0
-  if(MSVC_VERSION LESS 1800)
-    add_compile_options($<$<COMPILE_LANGUAGE:C>:/TP>)
-  endif()
-  add_compile_options($<$<COMPILE_LANGUAGE:C>:/D_CRT_SECURE_NO_WARNINGS>)
-elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES Clang)
-  add_compile_options($<$<COMPILE_LANGUAGE:C>:-Wall>)
-  add_compile_options($<$<COMPILE_LANGUAGE:C>:-Wextra>)
-  add_compile_options($<$<COMPILE_LANGUAGE:C>:-pedantic>)
-endif()
-
 # Check integrity of node structure when compiled as debug
 add_compile_options($<$<CONFIG:Debug>:-DCMARK_DEBUG_NODES>)
 
-add_compile_options($<$<AND:$<CONFIG:PROFILE>,$<COMPILE_LANGUAGE:C>>:-pg>)
-
-if(CMAKE_BUILD_TYPE STREQUAL Ubsan)
-  add_compile_options($<$<COMPILE_LANGUAGE:C>:-fsanitize=undefined>)
-endif()
-if(CMARK_LIB_FUZZER)
-  add_compile_options($<$<COMPILE_LANGUAGE:C>:-fsanitize-coverage=trace-pc-guard>)
-endif()
+# In order to maintain compatibility with older platforms which may not have a
+# recent version of CMake (i.e. are running CMake <3.3), we cannot simply use
+# the `add_compile_options` with a generator expression.  This uses the
+# `target_compile_options` with `PRIVATE` to add the flags only to the targets
+# so that CMark may be used in projects with non-C languages.
+function(cmark_add_compile_options target)
+  if(MSVC)
+    target_compile_options(${target} PRIVATE /W4 /wd4706)
+    if(MSVC_VERSION LESS 1800)
+      target_compile_options(${target} PRIVATE /TP)
+    endif()
+    target_compile_definitions(${target} PRIVATE _CRT_SECURE_NO_WARNINGS)
+  else()
+    target_compile_options(${target} PRIVATE -Wall -Wextra -pedantic)
+  endif()
+  if(CMAKE_BUILD_TYPE MATCHES profile)
+    target_compile_options(${target} PRIVATE -pg)
+  endif()
+  if(CMAKE_BUILD_TYPE MATCHES ubsan)
+    target_compile_options(${target} PRIVATE -fsanitize=undefined)
+  endif()
+  if(CMARK_LIB_FUZZER)
+    target_compile_options(${target} PRIVATE -fsanitize-coverage=trace-pc-guard)
+  endif()
+endfunction()
 
 add_subdirectory(src)
 if(CMARK_TESTS AND (CMARK_SHARED OR CMARK_STATIC))

--- a/api_test/CMakeLists.txt
+++ b/api_test/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(api_test
   harness.h
   main.c
 )
+cmark_add_compile_options(api_test)
 if(CMARK_SHARED)
   target_link_libraries(api_test cmark)
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ include(GNUInstallDirs)
 include (GenerateExportHeader)
 
 add_executable(${PROGRAM} ${PROGRAM_SOURCES})
+cmark_add_compile_options(${PROGRAM})
 set_target_properties(${PROGRAM} PROPERTIES
   OUTPUT_NAME "cmark")
 
@@ -71,6 +72,7 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
 if (CMARK_SHARED)
   add_library(${LIBRARY} SHARED ${LIBRARY_SOURCES})
+  cmark_add_compile_options(${LIBRARY})
   set_target_properties(${LIBRARY} PROPERTIES
     MACOSX_RPATH TRUE
     OUTPUT_NAME "cmark"
@@ -93,6 +95,7 @@ endif()
 
 if (CMARK_STATIC)
   add_library(${STATICLIBRARY} STATIC ${LIBRARY_SOURCES})
+  cmark_add_compile_options(${STATICLIBRARY})
   set_target_properties(${STATICLIBRARY} PROPERTIES
     COMPILE_FLAGS -DCMARK_STATIC_DEFINE
     OUTPUT_NAME "cmark$<$<BOOL:${MSVC}>:_static>"
@@ -188,6 +191,7 @@ CONFIGURE_FILE(
 
 if(CMARK_LIB_FUZZER)
   add_executable(cmark-fuzz ../test/cmark-fuzz.c ${LIBRARY_SOURCES})
+  cmark_add_compile_options(cmark-fuzz)
   target_link_libraries(cmark-fuzz "${CMAKE_LIB_FUZZER_PATH}")
 
   # cmark is written in C but the libFuzzer runtime is written in C++ which


### PR DESCRIPTION
The `COMPILE_LANGUAGE` generator expression was introduced in CMake 3.3.
Debian Jessie has an older CMake version bundled, which prevents
building on that platform without manually building CMake.  This
uses a more error-prone mechanism of requiring the commonmark developer
to explicitly invoke `cmark_add_compile_options` on the target to ensure
that the flags are propagated for the targets without using the
generator expression.  Adding the options unconditionally prevents using
CMark in a build with a non-C programming language.

Fixes: #384