### PR TITLE
Support nested lists in groff man

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -605,6 +605,7 @@ static void render_man(test_batch_runner *runner) {
   man = cmark_render_man(doc, CMARK_OPT_DEFAULT, 20);
   STR_EQ(runner, man, ".PP\n"
                       "foo \\f[I]bar\\f[]\n"
+                      ".RS\n"
                       ".IP \\[bu] 2\n"
                       "Lorem ipsum dolor\n"
                       "sit amet,\n"
@@ -614,18 +615,21 @@ static void render_man(test_batch_runner *runner) {
                       "sed do eiusmod\n"
                       "tempor incididunt ut\n"
                       "labore et dolore\n"
-                      "magna aliqua.\n",
+                      "magna aliqua.\n"
+                      ".RE\n",
          "render document with wrapping");
   free(man);
   man = cmark_render_man(doc, CMARK_OPT_DEFAULT, 0);
   STR_EQ(runner, man, ".PP\n"
                       "foo \\f[I]bar\\f[]\n"
+                      ".RS\n"
                       ".IP \\[bu] 2\n"
                       "Lorem ipsum dolor sit amet,\n"
                       "consectetur adipiscing elit,\n"
                       ".IP \\[bu] 2\n"
                       "sed do eiusmod tempor incididunt\n"
-                      "ut labore et dolore magna aliqua.\n",
+                      "ut labore et dolore magna aliqua.\n"
+                      ".RE\n",
          "render document without wrapping");
   free(man);
   cmark_node_free(doc);

--- a/src/man.c
+++ b/src/man.c
@@ -85,6 +85,7 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
     break;
 
   case CMARK_NODE_BLOCK_QUOTE:
+  case CMARK_NODE_LIST:
     if (entering) {
       CR();
       LIT(".RS");
@@ -94,9 +95,6 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       LIT(".RE");
       CR();
     }
-    break;
-
-  case CMARK_NODE_LIST:
     break;
 
   case CMARK_NODE_ITEM:


### PR DESCRIPTION
Lists are now nested properly when converting to groff man format.

Previously, nothing happened during conversion when a new list begun
inside another, leading to all lists being flattened. This commit
now has block quotes and lists handled the same: indent when a new
list is seen. From what I can tell, this is how nested lists are
supposed to be handled in the groff man format.

The tests were updated, and pass.