### PR TITLE
Fix install paths in libcmark.pc

### DIFF
--- a/src/libcmark.pc.in
+++ b/src/libcmark.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: libcmark
 Description: CommonMark parsing, rendering, and manipulation


### PR DESCRIPTION
`CMAKE_INSTALL_<dir>` can be relative or absolute path, so it is wrong to prefix `CMAKE_INSTALL_PREFIX` because if `CMAKE_INSTALL_<dir>` is set to an absolute path it will result in a malformed path with two absolute paths joined together:

    $ cmake -DCMAKE_INSTALL_PREFIX=/foo/bar \
        -DCMAKE_INSTALL_BINDIR=/foo/bar/bin \
        -DCMAKE_INSTALL_LIBDIR=/foo/bar/lib \
        -DCMAKE_INSTALL_INCLUDEDIR=/foo/bar/include \
        ..

    $ cat src/libcmark.pc
    prefix=/foo/bar
    exec_prefix=/foo/bar
    libdir=/foo/bar//foo/bar/lib
    includedir=/foo/bar//foo/bar/include
    ...

The `libdir` and `includedir` should be set by either calculating the directories relative to the prefix or by using the `CMAKE_INSTALL_FULL_<dir>` variables from `GNUInstallDirs`.

The `CMAKE_INSTALL_FULL_<dir>` variables seem the simpler solution.

-------

The issue was observed with Nix package manager, which sets all `CMAKE_INSTALL_<dir>` variables to the full path of the Nix store when building the package:

```
$ nix-env -f'<unstable>' -iA cmark
$ cat /nix/store/q57a8pzqlfh0nfn0ncl5nxzksfshf1j8-cmark-0.30.1/lib/pkgconfig/libcmark.pc
prefix=/nix/store/q57a8pzqlfh0nfn0ncl5nxzksfshf1j8-cmark-0.30.1
exec_prefix=/nix/store/q57a8pzqlfh0nfn0ncl5nxzksfshf1j8-cmark-0.30.1
libdir=/nix/store/q57a8pzqlfh0nfn0ncl5nxzksfshf1j8-cmark-0.30.1//nix/store/q57a8pzqlfh0nfn0ncl5nxzksfshf1j8-cmark-0.30.1/lib
includedir=/nix/store/q57a8pzqlfh0nfn0ncl5nxzksfshf1j8-cmark-0.30.1//nix/store/q57a8pzqlfh0nfn0ncl5nxzksfshf1j8-cmark-0.30.1/include

Name: libcmark
Description: CommonMark parsing, rendering, and manipulation
Version: 0.30.1
Libs: -L${libdir} -lcmark
Cflags: -I${includedir}
```