### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.7)
 project(cmark VERSION 0.30.1)
 
 include("FindAsan.cmake")


### PR DESCRIPTION
Bump the minimum required CMake to 3.7.  CMake 3.1 is required for the `CMAKE_C_STANDARD` and `CMAKE_C_STANDARD_REQUIRED` options to take effect.  Relying on CMake to control the compiler this way allows us to avoid having to rebuild the logic for detecting the appropriate flags and ensuring that the compiler is able to support the necessary language version.