### PR TITLE
Fix parsing of emphasis before links

### DIFF
--- a/src/inlines.c
+++ b/src/inlines.c
@@ -640,7 +640,8 @@ static cmark_node *handle_period(subject *subj, bool smart) {
 }
 
 static void process_emphasis(subject *subj, bufsize_t stack_bottom) {
-  delimiter *closer = subj->last_delim;
+  delimiter *candidate;
+  delimiter *closer = NULL;
   delimiter *opener;
   delimiter *old_closer;
   bool opener_found;
@@ -650,10 +651,10 @@ static void process_emphasis(subject *subj, bufsize_t stack_bottom) {
                                  stack_bottom, stack_bottom, stack_bottom};
 
   // move back to first relevant delim.
-  while (closer != NULL &&
-         closer->previous != NULL &&
-         closer->previous->position >= stack_bottom) {
-    closer = closer->previous;
+  candidate = subj->last_delim;
+  while (candidate != NULL && candidate->position >= stack_bottom) {
+    closer = candidate;
+    candidate = candidate->previous;
   }
 
   // now move forward, looking for closers, and handling each

--- a/test/regression.txt
+++ b/test/regression.txt
@@ -190,3 +190,11 @@ Issue #383 - emphasis parsing.
 <p>**<em><strong>Hello<em>world</em></strong></em></p>
 ````````````````````````````````
 
+Issue #424 - emphasis before links
+
+```````````````````````````````` example
+*text* [link](#section)
+.
+<p><em>text</em> <a href="#section">link</a></p>
+````````````````````````````````
+


### PR DESCRIPTION
Fix a regression introduced with commit ed0a4bf. Also test the first
delimiter against stack_bottom in process_emphasis. This happened to
work with the old code and only resulted in an unnecessary scan.

Fixes #424.