### PR TITLE
Add Windows artifact to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,8 @@ jobs:
         chcp 65001
         nmake.exe /nologo /f Makefile.nmake test
       shell: cmd
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: cmark ${{ matrix.cmake_opts }}
+        path: build/src/cmark.exe


### PR DESCRIPTION
This is for #291 since #294 wasn't carried over in the switch over to GitHub Actions.

The binary could also be included in future releases on GitHub if wished.