### PR TITLE
[437] Clang-Tidy: Narrowing conversion is implementation-defined

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -55,11 +55,11 @@ static void S_set_last_line_checked(cmark_node *node) {
   node->flags |= CMARK_NODE__LAST_LINE_CHECKED;
 }
 
-static CMARK_INLINE bool S_is_line_end_char(char c) {
+static CMARK_INLINE bool S_is_line_end_char(unsigned char c) {
   return (c == '\n' || c == '\r');
 }
 
-static CMARK_INLINE bool S_is_space_or_tab(char c) {
+static CMARK_INLINE bool S_is_space_or_tab(unsigned char c) {
   return (c == ' ' || c == '\t');
 }
 

--- a/src/cmark_ctype.c
+++ b/src/cmark_ctype.c
@@ -4,7 +4,7 @@
 
 /** 1 = space, 2 = punct, 3 = digit, 4 = alpha, 0 = other
  */
-static const uint8_t cmark_ctype_class[256] = {
+static const unsigned char cmark_ctype_class[256] = {
     /*      0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f */
     /* 0 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0,
     /* 1 */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -26,19 +26,19 @@ static const uint8_t cmark_ctype_class[256] = {
 /**
  * Returns 1 if c is a "whitespace" character as defined by the spec.
  */
-int cmark_isspace(char c) { return cmark_ctype_class[(uint8_t)c] == 1; }
+int cmark_isspace(unsigned char c) { return cmark_ctype_class[(uint8_t)c] == 1; }
 
 /**
  * Returns 1 if c is an ascii punctuation character.
  */
-int cmark_ispunct(char c) { return cmark_ctype_class[(uint8_t)c] == 2; }
+int cmark_ispunct(unsigned char c) { return cmark_ctype_class[(uint8_t)c] == 2; }
 
-int cmark_isalnum(char c) {
+int cmark_isalnum(unsigned char c) {
   uint8_t result;
   result = cmark_ctype_class[(uint8_t)c];
   return (result == 3 || result == 4);
 }
 
-int cmark_isdigit(char c) { return cmark_ctype_class[(uint8_t)c] == 3; }
+int cmark_isdigit(unsigned char c) { return cmark_ctype_class[(uint8_t)c] == 3; }
 
-int cmark_isalpha(char c) { return cmark_ctype_class[(uint8_t)c] == 4; }
+int cmark_isalpha(unsigned char c) { return cmark_ctype_class[(uint8_t)c] == 4; }

--- a/src/cmark_ctype.h
+++ b/src/cmark_ctype.h
@@ -9,15 +9,15 @@ extern "C" {
  * We want cmark to behave the same no matter what the system locale.
  */
 
-int cmark_isspace(char c);
+int cmark_isspace(unsigned char c);
 
-int cmark_ispunct(char c);
+int cmark_ispunct(unsigned char c);
 
-int cmark_isalnum(char c);
+int cmark_isalnum(unsigned char c);
 
-int cmark_isdigit(char c);
+int cmark_isdigit(unsigned char c);
 
-int cmark_isalpha(char c);
+int cmark_isalpha(unsigned char c);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes #437 