### PR TITLE
Shrink struct cmark_node

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -995,7 +995,7 @@ static void open_new_blocks(cmark_parser *parser, cmark_node **container,
 
       (*container)->as.heading.level = level;
       (*container)->as.heading.setext = false;
-      (*container)->internal_offset = matched;
+      (*container)->as.heading.internal_offset = matched;
 
     } else if (!indented && (matched = scan_open_code_fence(
                                  input, parser->first_nonspace))) {

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -1381,9 +1381,11 @@ static int parse_inline(subject *subj, cmark_node *parent, int options) {
 // Parse inlines from parent's string_content, adding as children of parent.
 void cmark_parse_inlines(cmark_mem *mem, cmark_node *parent,
                          cmark_reference_map *refmap, int options) {
+  int internal_offset = parent->type == CMARK_NODE_HEADING ?
+    parent->as.heading.internal_offset : 0;
   subject subj;
   cmark_chunk content = {parent->data, parent->len};
-  subject_from_buf(mem, parent->start_line, parent->start_column - 1 + parent->internal_offset, &subj, &content, refmap);
+  subject_from_buf(mem, parent->start_line, parent->start_column - 1 + internal_offset, &subj, &content, refmap);
   cmark_chunk_rtrim(&subj.input);
 
   while (!is_eof(&subj) && parse_inline(&subj, parent, options))

--- a/src/node.h
+++ b/src/node.h
@@ -31,7 +31,8 @@ typedef struct {
 } cmark_code;
 
 typedef struct {
-  int level;
+  int internal_offset;
+  int8_t level;
   bool setext;
 } cmark_heading;
 
@@ -69,7 +70,6 @@ struct cmark_node {
   int start_column;
   int end_line;
   int end_column;
-  int internal_offset;
   uint16_t type;
   uint16_t flags;
 


### PR DESCRIPTION
The internal_offset member is only used for headings and can be moved
to struct cmark_heading. This reduces the size of struct cmark_node
from 112 to 104 bytes on 64-bit systems.