### PR TITLE
Fix -Wstrict-prototypes warnings

### DIFF
--- a/src/cmark.c
+++ b/src/cmark.c
@@ -6,9 +6,9 @@
 #include "cmark.h"
 #include "buffer.h"
 
-int cmark_version() { return CMARK_VERSION; }
+int cmark_version(void) { return CMARK_VERSION; }
 
-const char *cmark_version_string() { return CMARK_VERSION_STRING; }
+const char *cmark_version_string(void) { return CMARK_VERSION_STRING; }
 
 static void *xcalloc(size_t nmem, size_t size) {
   void *ptr = calloc(nmem, size);
@@ -30,7 +30,7 @@ static void *xrealloc(void *ptr, size_t size) {
 
 cmark_mem DEFAULT_MEM_ALLOCATOR = {xcalloc, xrealloc, free};
 
-cmark_mem *cmark_get_default_mem_allocator() {
+cmark_mem *cmark_get_default_mem_allocator(void) {
   return &DEFAULT_MEM_ALLOCATOR;
 }
 


### PR DESCRIPTION
Downstream maintainers for CRAN (R package repository) have started enforcing ` -Wstrict-prototypes` warnings, in prep for clang-15.