### PR TITLE
chore: Add dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 jobs:
 
@@ -54,7 +58,7 @@ jobs:
 
   macos:
 
-    runs-on: macOS-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Will keep things like `actions/checkout@v1` up-to-date, as V3 is the current version.
Filtered out the CI jobs so that the dependabot branches doen't build on push, but only on the PRs that it opens.
The `macos-latest` casing was because the schema validation in VSCode was flagging it, but it could be pulled out