### PR TITLE
Creating a PHP wrapper example

### DIFF
--- a/wrappers/wrapper.php
+++ b/wrappers/wrapper.php
@@ -1,0 +1,18 @@
+<?php
+
+$ffi = FFI::cdef(
+    'char *cmark_markdown_to_html(const char *text, size_t len, int options);',
+    'libcmark.so'
+);
+$markdown = <<<'md'
+# First level title
+
+## Second level title
+
+Paragraph
+
+md;
+
+$html = FFI::string($ffi->cmark_markdown_to_html($markdown, strlen($markdown), 0));
+
+echo $html . PHP_EOL;


### PR DESCRIPTION
Adding a PHP wrapper example using FFI.

Instead of using stdin, I chose to have a default markdown just to be more simple to execute the test. But that can be changed if preferred.