### PR TITLE
Keep an incremental count of open block types

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -235,15 +235,18 @@ static void remove_trailing_blank_lines(cmark_strbuf *ln) {
 // Check to see if a node ends with a blank line, descending
 // if needed into lists and sublists.
 static bool S_ends_with_blank_line(cmark_node *node) {
-  if (S_last_line_checked(node)) {
-    return(S_last_line_blank(node));
-  } else if ((S_type(node) == CMARK_NODE_LIST ||
-              S_type(node) == CMARK_NODE_ITEM) && node->last_child) {
-    S_set_last_line_checked(node);
-    return(S_ends_with_blank_line(node->last_child));
-  } else {
-    S_set_last_line_checked(node);
-    return (S_last_line_blank(node));
+  while (true) {
+    if (S_last_line_checked(node)) {
+      return(S_last_line_blank(node));
+    } else if ((S_type(node) == CMARK_NODE_LIST ||
+                S_type(node) == CMARK_NODE_ITEM) && node->last_child) {
+      S_set_last_line_checked(node);
+      node = node->last_child;
+      continue;
+    } else {
+      S_set_last_line_checked(node);
+      return (S_last_line_blank(node));
+    }
   }
 }
 
@@ -975,6 +978,7 @@ static cmark_node *check_open_blocks(cmark_parser *parser, cmark_chunk *input,
               // fall through
             case CMARK_NODE_CODE_BLOCK:
             case CMARK_NODE_PARAGRAPH:
+            case CMARK_NODE_HTML_BLOCK:
               // Jump to parser->current
               container = parser->current;
               cont_type = S_type(container);

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -131,6 +131,7 @@ cmark_parser *cmark_parser_new_with_mem(int options, cmark_mem *mem) {
   parser->last_line_length = 0;
   parser->options = options;
   parser->last_buffer_ended_with_cr = false;
+  add_open_block_counts(parser, document);
 
   return parser;
 }
@@ -1121,7 +1122,7 @@ static void open_new_blocks(cmark_parser *parser, cmark_node **container,
       has_content = resolve_reference_link_definitions(parser);
 
       if (has_content) {
-        cmark_node_set_type(*container, CMARK_NODE_HEADING);
+        (*container)->type = CMARK_NODE_HEADING;
         decr_open_block_count(parser, CMARK_NODE_PARAGRAPH);
         incr_open_block_count(parser, CMARK_NODE_HEADING);
         (*container)->as.heading.level = lev;

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -393,9 +393,11 @@ static cmark_node *finalize(cmark_parser *parser, cmark_node *b) {
 // in parser. (Used to check that the counts in parser, which are updated incrementally, are
 // correct.)
 bool check_open_block_counts(cmark_parser *parser) {
-  cmark_parser tmp_parser = {0}; // Only used for its open_block_counts field.
+  cmark_parser tmp_parser = {0}; // Only used for its open_block_counts and total_open_blocks fields.
   add_open_block_counts(&tmp_parser, parser->root);
-  return memcmp(tmp_parser.open_block_counts, parser->open_block_counts, sizeof(parser->open_block_counts)) == 0;
+  return
+    tmp_parser.total_open_blocks == parser->total_open_blocks &&
+    memcmp(tmp_parser.open_block_counts, parser->open_block_counts, sizeof(parser->open_block_counts)) == 0;
 }
 
 // Add a node as child of another.  Return pointer to child.
@@ -926,14 +928,38 @@ static cmark_node *check_open_blocks(cmark_parser *parser, cmark_chunk *input,
   *all_matched = false;
   cmark_node *container = parser->root;
   cmark_node_type cont_type;
+  cmark_parser tmp_parser; // Only used for its open_block_counts and total_open_blocks fields.
+  memcpy(tmp_parser.open_block_counts, parser->open_block_counts, sizeof(parser->open_block_counts));
+  tmp_parser.total_open_blocks = parser->total_open_blocks;
 
   assert(check_open_block_counts(parser));
 
   while (S_last_child_is_open(container)) {
+    decr_open_block_count(&tmp_parser, S_type(container));
     container = container->last_child;
     cont_type = S_type(container);
 
     S_find_first_nonspace(parser, input);
+
+    if (parser->blank) {
+      const size_t n_list = read_open_block_count(&tmp_parser, CMARK_NODE_LIST);
+      const size_t n_item = read_open_block_count(&tmp_parser, CMARK_NODE_ITEM);
+      const size_t n_para = read_open_block_count(&tmp_parser, CMARK_NODE_PARAGRAPH);
+      if (n_list + n_item + n_para == tmp_parser.total_open_blocks) {
+        if (parser->current->flags & CMARK_NODE__OPEN_BLOCK) {
+          if (S_type(parser->current) == CMARK_NODE_PARAGRAPH) {
+            container = parser->current;
+            goto done;
+          }
+          if (S_type(parser->current) == CMARK_NODE_ITEM) {
+            if (parser->current->flags & CMARK_NODE__OPEN) {
+              container = parser->current;
+              cont_type = S_type(container);
+            }
+          }
+        }
+      }
+    }
 
     switch (cont_type) {
     case CMARK_NODE_BLOCK_QUOTE:
@@ -1189,7 +1215,7 @@ static void add_text_to_container(cmark_parser *parser, cmark_node *container,
   S_set_last_line_blank(container, last_line_blank);
 
   tmp = container;
-  while (tmp->parent) {
+  while (tmp->parent && S_last_line_blank(tmp->parent)) {
     S_set_last_line_blank(tmp->parent, false);
     tmp = tmp->parent;
   }

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -69,6 +69,22 @@ static void S_parser_feed(cmark_parser *parser, const unsigned char *buffer,
 static void S_process_line(cmark_parser *parser, const unsigned char *buffer,
                            bufsize_t bytes);
 
+static void subtract_open_block_counts(cmark_parser *parser, cmark_node *node) {
+  do {
+    decr_open_block_count(parser, S_type(node));
+    node->flags &= ~CMARK_NODE__OPEN_BLOCK;
+    node = node->last_child;
+  } while (node);
+}
+
+static void add_open_block_counts(cmark_parser *parser, cmark_node *node) {
+  do {
+    incr_open_block_count(parser, S_type(node));
+    node->flags |= CMARK_NODE__OPEN_BLOCK;
+    node = node->last_child;
+  } while (node);
+}
+
 static cmark_node *make_block(cmark_mem *mem, cmark_node_type tag,
                               int start_line, int start_column) {
   cmark_node *e;
@@ -285,6 +301,12 @@ static cmark_node *finalize(cmark_parser *parser, cmark_node *b) {
     has_content = resolve_reference_link_definitions(parser);
     if (!has_content) {
       // remove blank node (former reference def)
+      if (b->flags & CMARK_NODE__OPEN_BLOCK) {
+        decr_open_block_count(parser, S_type(b));
+        if (b->prev) {
+          add_open_block_counts(parser, b->prev);
+        }
+      }
       cmark_node_free(b);
     } else {
       b->len = node_content->size;
@@ -367,6 +389,15 @@ static cmark_node *finalize(cmark_parser *parser, cmark_node *b) {
   return parent;
 }
 
+// Recalculates the number of open blocks. Returns true if it matches what's currently stored
+// in parser. (Used to check that the counts in parser, which are updated incrementally, are
+// correct.)
+bool check_open_block_counts(cmark_parser *parser) {
+  cmark_parser tmp_parser = {0}; // Only used for its open_block_counts field.
+  add_open_block_counts(&tmp_parser, parser->root);
+  return memcmp(tmp_parser.open_block_counts, parser->open_block_counts, sizeof(parser->open_block_counts)) == 0;
+}
+
 // Add a node as child of another.  Return pointer to child.
 static cmark_node *add_child(cmark_parser *parser, cmark_node *parent,
                              cmark_node_type block_type, int start_column) {
@@ -385,11 +416,14 @@ static cmark_node *add_child(cmark_parser *parser, cmark_node *parent,
   if (parent->last_child) {
     parent->last_child->next = child;
     child->prev = parent->last_child;
+    subtract_open_block_counts(parser, parent->last_child);
   } else {
     parent->first_child = child;
     child->prev = NULL;
   }
   parent->last_child = child;
+  add_open_block_counts(parser, child);
+
   return child;
 }
 
@@ -893,6 +927,8 @@ static cmark_node *check_open_blocks(cmark_parser *parser, cmark_chunk *input,
   cmark_node *container = parser->root;
   cmark_node_type cont_type;
 
+  assert(check_open_block_counts(parser));
+
   while (S_last_child_is_open(container)) {
     container = container->last_child;
     cont_type = S_type(container);
@@ -1029,8 +1065,9 @@ static void open_new_blocks(cmark_parser *parser, cmark_node **container,
       has_content = resolve_reference_link_definitions(parser);
 
       if (has_content) {
-
-        (*container)->type = (uint16_t)CMARK_NODE_HEADING;
+        cmark_node_set_type(*container, CMARK_NODE_HEADING);
+        decr_open_block_count(parser, CMARK_NODE_PARAGRAPH);
+        incr_open_block_count(parser, CMARK_NODE_HEADING);
         (*container)->as.heading.level = lev;
         (*container)->as.heading.setext = true;
         S_advance_offset(parser, input, input->len - 1 - parser->offset, false);
@@ -1271,6 +1308,7 @@ static void S_process_line(cmark_parser *parser, const unsigned char *buffer,
 
   parser->line_number++;
 
+  assert(parser->current->next == NULL);
   last_matched_container = check_open_blocks(parser, &input, &all_matched);
 
   if (!last_matched_container)

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -941,17 +941,41 @@ static cmark_node *check_open_blocks(cmark_parser *parser, cmark_chunk *input,
 
     S_find_first_nonspace(parser, input);
 
-    if (parser->blank) {
-      const size_t n_list = read_open_block_count(&tmp_parser, CMARK_NODE_LIST);
-      const size_t n_item = read_open_block_count(&tmp_parser, CMARK_NODE_ITEM);
-      const size_t n_para = read_open_block_count(&tmp_parser, CMARK_NODE_PARAGRAPH);
-      if (n_list + n_item + n_para == tmp_parser.total_open_blocks) {
-        if (parser->current->flags & CMARK_NODE__OPEN_BLOCK) {
-          if (parser->current->flags & CMARK_NODE__OPEN) {
+    // This block of code is a workaround for the quadratic performance
+    // issue described here (issue 2):
+    //
+    // https://github.com/github/cmark-gfm/security/advisories/GHSA-66g8-4hjf-77xh
+    //
+    // If the current line is empty then we might be able to skip directly
+    // to the end of the list of open blocks. To determine whether this is
+    // possible, we have been maintaining a count of the number of
+    // different types of open blocks. The main criterium is that every
+    // remaining block, except the last element of the list, is a LIST or
+    // ITEM. The code below checks the conditions, and if they're ok, skips
+    // forward to parser->current.
+    if (parser->blank && parser->indent == 0) {  // Current line is empty
+      // Make sure that parser->current doesn't point to a closed block.
+      if (parser->current->flags & CMARK_NODE__OPEN_BLOCK) {
+        if (parser->current->flags & CMARK_NODE__OPEN) {
+          const size_t n_list = read_open_block_count(&tmp_parser, CMARK_NODE_LIST);
+          const size_t n_item = read_open_block_count(&tmp_parser, CMARK_NODE_ITEM);
+          // At most one block can be something other than a LIST or ITEM.
+          if (n_list + n_item + 1 >= tmp_parser.total_open_blocks) {
+            // Check that parser->current is suitable for jumping to.
             switch (S_type(parser->current)) {
-            case CMARK_NODE_PARAGRAPH:
             case CMARK_NODE_LIST:
             case CMARK_NODE_ITEM:
+              if (n_list + n_item != tmp_parser.total_open_blocks) {
+                if (parser->current->last_child == NULL) {
+                  // There's another node type somewhere in the middle of
+                  // the list, so don't attempt the optimization.
+                  break;
+                }
+              }
+              // fall through
+            case CMARK_NODE_CODE_BLOCK:
+            case CMARK_NODE_PARAGRAPH:
+              // Jump to parser->current
               container = parser->current;
               cont_type = S_type(container);
               break;

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -947,14 +947,16 @@ static cmark_node *check_open_blocks(cmark_parser *parser, cmark_chunk *input,
       const size_t n_para = read_open_block_count(&tmp_parser, CMARK_NODE_PARAGRAPH);
       if (n_list + n_item + n_para == tmp_parser.total_open_blocks) {
         if (parser->current->flags & CMARK_NODE__OPEN_BLOCK) {
-          if (S_type(parser->current) == CMARK_NODE_PARAGRAPH) {
-            container = parser->current;
-            goto done;
-          }
-          if (S_type(parser->current) == CMARK_NODE_ITEM) {
-            if (parser->current->flags & CMARK_NODE__OPEN) {
+          if (parser->current->flags & CMARK_NODE__OPEN) {
+            switch (S_type(parser->current)) {
+            case CMARK_NODE_PARAGRAPH:
+            case CMARK_NODE_LIST:
+            case CMARK_NODE_ITEM:
               container = parser->current;
               cont_type = S_type(container);
+              break;
+            default:
+              break;
             }
           }
         }

--- a/src/cmark.h
+++ b/src/cmark.h
@@ -30,6 +30,16 @@ char *cmark_markdown_to_html(const char *text, size_t len, int options);
 /** ## Node Structure
  */
 
+/**
+ * This is the maximum number of block types (CMARK_NODE_DOCUMENT,
+ * CMARK_NODE_HEADING, ...). It needs to be bigger than the number of
+ * hardcoded block types (below) to allow for extensions (see
+ * cmark_syntax_extension_add_node). But it also determines the size of the
+ * open_block_counts array in the cmark_parser struct, so we don't want it
+ * to be excessively large.
+ */
+#define CMARK_NODE_TYPE_BLOCK_LIMIT 0x20
+
 typedef enum {
   /* Error status */
   CMARK_NODE_NONE,

--- a/src/node.h
+++ b/src/node.h
@@ -48,8 +48,9 @@ typedef struct {
 
 enum cmark_node__internal_flags {
   CMARK_NODE__OPEN = (1 << 0),
-  CMARK_NODE__LAST_LINE_BLANK = (1 << 1),
-  CMARK_NODE__LAST_LINE_CHECKED = (1 << 2),
+  CMARK_NODE__OPEN_BLOCK = (1 << 1),
+  CMARK_NODE__LAST_LINE_BLANK = (1 << 2),
+  CMARK_NODE__LAST_LINE_CHECKED = (1 << 3),
 };
 
 struct cmark_node {

--- a/src/parser.h
+++ b/src/parser.h
@@ -49,12 +49,14 @@ struct cmark_parser {
    * For example, CMARK_NODE_LIST (0x8003) is stored at offset 2.
    */
   size_t open_block_counts[CMARK_NODE_TYPE_BLOCK_LIMIT];
+  size_t total_open_blocks;
 };
 
 static CMARK_INLINE void incr_open_block_count(cmark_parser *parser, cmark_node_type type) {
   assert(type > CMARK_NODE_TYPE_BLOCK);
   assert(type <= CMARK_NODE_TYPE_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
   parser->open_block_counts[type - CMARK_NODE_TYPE_BLOCK - 1]++;
+  parser->total_open_blocks++;
 }
 
 static CMARK_INLINE void decr_open_block_count(cmark_parser *parser, cmark_node_type type) {
@@ -62,6 +64,14 @@ static CMARK_INLINE void decr_open_block_count(cmark_parser *parser, cmark_node_
   assert(type <= CMARK_NODE_TYPE_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
   assert(parser->open_block_counts[type - CMARK_NODE_TYPE_BLOCK - 1] > 0);
   parser->open_block_counts[type - CMARK_NODE_TYPE_BLOCK - 1]--;
+  assert(parser->total_open_blocks > 0);
+  parser->total_open_blocks--;
+}
+
+static CMARK_INLINE size_t read_open_block_count(cmark_parser *parser, cmark_node_type type) {
+  assert(type > CMARK_NODE_TYPE_BLOCK);
+  assert(type <= CMARK_NODE_TYPE_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
+  return parser->open_block_counts[type - CMARK_NODE_TYPE_BLOCK - 1];
 }
 
 #ifdef __cplusplus

--- a/src/parser.h
+++ b/src/parser.h
@@ -52,6 +52,7 @@ struct cmark_parser {
   size_t total_open_blocks;
 };
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static CMARK_INLINE void incr_open_block_count(cmark_parser *parser, cmark_node_type type) {
   assert(type >= CMARK_NODE_FIRST_BLOCK);
   assert(type < CMARK_NODE_FIRST_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
@@ -59,6 +60,7 @@ static CMARK_INLINE void incr_open_block_count(cmark_parser *parser, cmark_node_
   parser->total_open_blocks++;
 }
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static CMARK_INLINE void decr_open_block_count(cmark_parser *parser, cmark_node_type type) {
   assert(type >= CMARK_NODE_FIRST_BLOCK);
   assert(type < CMARK_NODE_FIRST_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
@@ -68,6 +70,7 @@ static CMARK_INLINE void decr_open_block_count(cmark_parser *parser, cmark_node_
   parser->total_open_blocks--;
 }
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static CMARK_INLINE size_t read_open_block_count(cmark_parser *parser, cmark_node_type type) {
   assert(type >= CMARK_NODE_FIRST_BLOCK);
   assert(type < CMARK_NODE_FIRST_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);

--- a/src/parser.h
+++ b/src/parser.h
@@ -33,7 +33,36 @@ struct cmark_parser {
   int options;
   bool last_buffer_ended_with_cr;
   unsigned int total_size;
+
+  /**
+   * The "open" blocks are the blocks visited by the loop in
+   * check_open_blocks (blocks.c). I.e. the blocks in this list:
+   *
+   *   parser->root->last_child->...->last_child
+   *
+   * open_block_counts is used to keep track of how many of each type of
+   * node are currently in the open blocks list. Knowing these counts can
+   * sometimes help to end the loop in check_open_blocks early, improving
+   * efficiency.
+   *
+   * The count is stored at this offset: type - CMARK_NODE_TYPE_BLOCK - 1
+   * For example, CMARK_NODE_LIST (0x8003) is stored at offset 2.
+   */
+  size_t open_block_counts[CMARK_NODE_TYPE_BLOCK_LIMIT];
 };
+
+static CMARK_INLINE void incr_open_block_count(cmark_parser *parser, cmark_node_type type) {
+  assert(type > CMARK_NODE_TYPE_BLOCK);
+  assert(type <= CMARK_NODE_TYPE_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
+  parser->open_block_counts[type - CMARK_NODE_TYPE_BLOCK - 1]++;
+}
+
+static CMARK_INLINE void decr_open_block_count(cmark_parser *parser, cmark_node_type type) {
+  assert(type > CMARK_NODE_TYPE_BLOCK);
+  assert(type <= CMARK_NODE_TYPE_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
+  assert(parser->open_block_counts[type - CMARK_NODE_TYPE_BLOCK - 1] > 0);
+  parser->open_block_counts[type - CMARK_NODE_TYPE_BLOCK - 1]--;
+}
 
 #ifdef __cplusplus
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -45,33 +45,33 @@ struct cmark_parser {
    * sometimes help to end the loop in check_open_blocks early, improving
    * efficiency.
    *
-   * The count is stored at this offset: type - CMARK_NODE_TYPE_BLOCK - 1
-   * For example, CMARK_NODE_LIST (0x8003) is stored at offset 2.
+   * The count is stored at this offset: type - CMARK_NODE_FIRST_BLOCK
+   * For example, CMARK_NODE_LIST (0x3) is stored at offset 2.
    */
   size_t open_block_counts[CMARK_NODE_TYPE_BLOCK_LIMIT];
   size_t total_open_blocks;
 };
 
 static CMARK_INLINE void incr_open_block_count(cmark_parser *parser, cmark_node_type type) {
-  assert(type > CMARK_NODE_TYPE_BLOCK);
-  assert(type <= CMARK_NODE_TYPE_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
-  parser->open_block_counts[type - CMARK_NODE_TYPE_BLOCK - 1]++;
+  assert(type >= CMARK_NODE_FIRST_BLOCK);
+  assert(type < CMARK_NODE_FIRST_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
+  parser->open_block_counts[type - CMARK_NODE_FIRST_BLOCK]++;
   parser->total_open_blocks++;
 }
 
 static CMARK_INLINE void decr_open_block_count(cmark_parser *parser, cmark_node_type type) {
-  assert(type > CMARK_NODE_TYPE_BLOCK);
-  assert(type <= CMARK_NODE_TYPE_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
-  assert(parser->open_block_counts[type - CMARK_NODE_TYPE_BLOCK - 1] > 0);
-  parser->open_block_counts[type - CMARK_NODE_TYPE_BLOCK - 1]--;
+  assert(type >= CMARK_NODE_FIRST_BLOCK);
+  assert(type < CMARK_NODE_FIRST_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
+  assert(parser->open_block_counts[type - CMARK_NODE_FIRST_BLOCK] > 0);
+  parser->open_block_counts[type - CMARK_NODE_FIRST_BLOCK]--;
   assert(parser->total_open_blocks > 0);
   parser->total_open_blocks--;
 }
 
 static CMARK_INLINE size_t read_open_block_count(cmark_parser *parser, cmark_node_type type) {
-  assert(type > CMARK_NODE_TYPE_BLOCK);
-  assert(type <= CMARK_NODE_TYPE_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
-  return parser->open_block_counts[type - CMARK_NODE_TYPE_BLOCK - 1];
+  assert(type >= CMARK_NODE_FIRST_BLOCK);
+  assert(type < CMARK_NODE_FIRST_BLOCK + CMARK_NODE_TYPE_BLOCK_LIMIT);
+  return parser->open_block_counts[type - CMARK_NODE_FIRST_BLOCK];
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
This is a rebase of the solution that we implemented in cmark-gfm to fix https://github.com/github/cmark-gfm/security/advisories/GHSA-66g8-4hjf-77xh.

The idea is to incrementally keep an up-to-date count of the number of "open" blocks, categorized by node type, so that the loop in `check_open_blocks` can bail out early when it can see from the counts that the rest of the list doesn't contain any nodes that need to be checked.

I've fuzzed this solution extensively on cmark-gfm, but not on cmark.

Reproduction steps for the bug that this PR fixes:

```bash
python3 -c 'n = 10000; print(" -" * n + "x" + "\n" * n)' | cmark
```

Increasing the number 10000 in the above command causes the running time to increase quadratically.