### PR TITLE
Fix quadratic performance issue in list numbering

### DIFF
--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -153,7 +153,6 @@ static bool is_autolink(cmark_node *node) {
 
 static int S_render_node(cmark_renderer *renderer, cmark_node *node,
                          cmark_event_type ev_type, int options) {
-  cmark_node *tmp;
   int list_number;
   cmark_delim_type list_delim;
   size_t numticks;
@@ -210,19 +209,15 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       LIT("<!-- end list -->");
       BLANKLINE();
     }
+    renderer->list_number = cmark_node_get_list_start(node);
     break;
 
   case CMARK_NODE_ITEM:
     if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {
       marker_width = 4;
     } else {
-      list_number = cmark_node_get_list_start(node->parent);
+      list_number = renderer->list_number++;
       list_delim = cmark_node_get_list_delim(node->parent);
-      tmp = node;
-      while (tmp->prev) {
-        tmp = tmp->prev;
-        list_number += 1;
-      }
       // we ensure a width of at least 4 so
       // we get nice transition from single digits
       // to double

--- a/src/man.c
+++ b/src/man.c
@@ -72,7 +72,6 @@ static void S_outc(cmark_renderer *renderer, cmark_escaping escape, int32_t c,
 
 static int S_render_node(cmark_renderer *renderer, cmark_node *node,
                          cmark_event_type ev_type, int options) {
-  cmark_node *tmp;
   int list_number;
   bool entering = (ev_type == CMARK_EVENT_ENTER);
   bool allow_wrap = renderer->width > 0 && !(CMARK_OPT_NOBREAKS & options);
@@ -112,6 +111,7 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
     break;
 
   case CMARK_NODE_LIST:
+    renderer->list_number = cmark_node_get_list_start(node);
     break;
 
   case CMARK_NODE_ITEM:
@@ -125,12 +125,7 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {
         LIT("\\[bu] 2");
       } else {
-        list_number = cmark_node_get_list_start(node->parent);
-        tmp = node;
-        while (tmp->prev) {
-          tmp = tmp->prev;
-          list_number += 1;
-        }
+        list_number = renderer->list_number++;
         char list_number_s[LIST_NUMBER_SIZE];
         snprintf(list_number_s, LIST_NUMBER_SIZE, "\"%d.\" 4", list_number);
         LIT(list_number_s);

--- a/src/render.c
+++ b/src/render.c
@@ -165,7 +165,7 @@ char *cmark_render(cmark_node *root, int options, int width,
   cmark_renderer renderer = {options,
                              mem,    &buf,    &pref,      0,      width,
                              0,      0,       true,       true,   false,
-                             false,  NULL,
+                             false,  0,       NULL,
                              outc,   S_cr,    S_blankline, S_out};
 
   while ((ev_type = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {

--- a/src/render.h
+++ b/src/render.h
@@ -28,6 +28,7 @@ struct cmark_renderer {
   bool begin_content;
   bool no_linebreaks;
   bool in_tight_list_item;
+  int list_number;
   struct block_number *block_number_in_list_item;
   void (*outc)(struct cmark_renderer *, cmark_escaping, int32_t, unsigned char);
   void (*cr)(struct cmark_renderer *);


### PR DESCRIPTION
This is a cherry-pick of one of the commits that we added in cmark-gfm to fix https://github.com/github/cmark-gfm/security/advisories/GHSA-r8vr-c48j-fcc5. (Only one of the bugs affects cmark too.)

To reproduce the bug:

```bash
python3 -c 'n = 10000; print("1.\n" + " 2.\n"*n)' | time ./src/cmark -t commonmark
python3 -c 'n = 10000; print("1.\n" + " 2.\n"*n)' | time ./src/cmark -t man
```

Increasing the number 10000 in the above command causes the running time to increase quadratically.

The solution is to keep track of the current item number, rather than recomputing it on every iteration by counting the number of elements in the list.