### PR TITLE
Track underscore bottom separately mod 3, like asterisk

### DIFF
--- a/src/inlines.c
+++ b/src/inlines.c
@@ -653,9 +653,11 @@ static void process_emphasis(subject *subj, bufsize_t stack_bottom) {
   delimiter *old_closer;
   bool opener_found;
   int openers_bottom_index = 0;
-  bufsize_t openers_bottom[9] = {stack_bottom, stack_bottom, stack_bottom,
-                                 stack_bottom, stack_bottom, stack_bottom,
-                                 stack_bottom, stack_bottom, stack_bottom};
+  bufsize_t openers_bottom[15] = {stack_bottom, stack_bottom, stack_bottom,
+                                  stack_bottom, stack_bottom, stack_bottom,
+                                  stack_bottom, stack_bottom, stack_bottom,
+                                  stack_bottom, stack_bottom, stack_bottom,
+                                  stack_bottom, stack_bottom, stack_bottom};
 
   // move back to first relevant delim.
   candidate = subj->last_delim;
@@ -675,10 +677,11 @@ static void process_emphasis(subject *subj, bufsize_t stack_bottom) {
         openers_bottom_index = 1;
         break;
       case '_':
-        openers_bottom_index = 2;
+        openers_bottom_index = 2 +
+                (closer->can_open ? 3 : 0) + (closer->length % 3);
         break;
       case '*':
-        openers_bottom_index = 3 +
+        openers_bottom_index = 8 +
                 (closer->can_open ? 3 : 0) + (closer->length % 3);
         break;
       default:

--- a/test/regression.txt
+++ b/test/regression.txt
@@ -212,4 +212,32 @@ x <!A>
 <p>x <!A></p>
 ````````````````````````````````
 
+An underscore that is not part of a delimiter should not prevent another
+pair of underscores from forming part of their own.
+```````````````````````````````` example
+__!_!__
+
+__!x!__
+
+**!*!**
+
+---
+
+_*__*_*
+
+_*xx*_*
+
+_*__-_-
+
+_*xx-_-
+.
+<p><strong>!_!</strong></p>
+<p><strong>!x!</strong></p>
+<p><strong>!*!</strong></p>
+<hr />
+<p><em><em>__</em></em>*</p>
+<p><em><em>xx</em></em>*</p>
+<p><em>*__-</em>-</p>
+<p><em>*xx-</em>-</p>
+````````````````````````````````
 


### PR DESCRIPTION
The reasoning that a failed delimiter means future delimiters will also fail only applies if the reason they failed was not the multiple-of-three rule. This was already implemented correctly for asterisks, but not for underscore.

This PR ports [#272] from commonmark.js to cmark.

[#272]: https://github.com/commonmark/commonmark.js/pull/272

Fixes #455