### PR TITLE
build: replace `CMARK_TESTS` with `BUILD_TESTING`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,12 @@ project(cmark VERSION 0.30.3)
 
 include("FindAsan.cmake")
 include(GNUInstallDirs)
+include(CTest)
 
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "Do not build in-source.\nPlease remove CMakeCache.txt and the CMakeFiles/ directory.\nThen: mkdir build ; cd build ; cmake .. ; make")
 endif()
 
-option(CMARK_TESTS "Build cmark tests and enable testing" ON)
 option(CMARK_STATIC "Build static libcmark library" ON)
 option(CMARK_SHARED "Build shared libcmark library" ON)
 option(CMARK_LIB_FUZZER "Build libFuzzer fuzzing harness" OFF)
@@ -60,16 +60,15 @@ function(cmark_add_compile_options target)
 endfunction()
 
 add_subdirectory(src)
-if(CMARK_TESTS AND (CMARK_SHARED OR CMARK_STATIC))
-  add_subdirectory(api_test)
-endif()
 # TODO(compnerd) should this be enabled for MinGW, which sets CMAKE_SYSTEM_NAME
 # to Windows, but defines `MINGW`.
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
   add_subdirectory(man)
 endif()
-if(CMARK_TESTS)
-  enable_testing()
+if(BUILD_TESTING)
+  if(CMARK_SHARED OR CMARK_STATIC)
+    add_subdirectory(api_test)
+  endif()
   add_subdirectory(test testdir)
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ prof:
 afl:
 	@[ -n "$(AFL_PATH)" ] || { echo '$$AFL_PATH not set'; false; }
 	mkdir -p $(BUILDDIR)
-	cd $(BUILDDIR) && cmake .. -DCMARK_TESTS=0 -DCMAKE_C_COMPILER=$(AFL_PATH)/afl-clang
+	cd $(BUILDDIR) && cmake .. -DBUILD_TESTING=NO -DCMAKE_C_COMPILER=$(AFL_PATH)/afl-clang
 	$(MAKE)
 	$(AFL_PATH)/afl-fuzz \
 	    -i test/afl_test_cases \

--- a/api_test/CMakeLists.txt
+++ b/api_test/CMakeLists.txt
@@ -10,3 +10,12 @@ if(CMARK_SHARED)
 else()
   target_link_libraries(api_test cmark_static)
 endif()
+
+add_test(NAME api_test COMMAND api_test)
+if(WIN32)
+  file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR}/src WIN_DLL_DIR)
+  set(NEWPATH "${WIN_DLL_DIR};$ENV{PATH}")
+  string(REPLACE ";" "\\;" NEWPATH "${NEWPATH}")
+  set_tests_properties(api_test PROPERTIES ENVIRONMENT "PATH=${NEWPATH}")
+endif()
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,15 +19,7 @@ else()
     IMPORTED_LOCATION ${PYTHON_EXECUTABLE})
 endif()
 
-if (CMARK_SHARED OR CMARK_STATIC)
-  add_test(NAME api_test COMMAND api_test)
-endif()
-
 if (WIN32)
-  file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR}/src WIN_DLL_DIR)
-  set(NEWPATH "${WIN_DLL_DIR};$ENV{PATH}")
-  string(REPLACE ";" "\\;" NEWPATH "${NEWPATH}")
-  set_tests_properties(api_test PROPERTIES ENVIRONMENT "PATH=${NEWPATH}")
   set(ROUNDTRIP "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip.bat")
 else(WIN32)
   set(ROUNDTRIP "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip.sh")
@@ -82,9 +74,7 @@ IF (Python_Interpreter_FOUND)
 
 ELSE(Python_Interpreter_FOUND)
 
-  message("\n*** A python 3 interpreter is required to run the spec tests.\n")
-  add_test(skipping_spectests
-    echo "Skipping spec tests, because no python 3 interpreter is available.")
+  message(WARNING "A Python 3 Interpreter is required to run the spec tests")
 
 ENDIF(Python_Interpreter_FOUND)
 


### PR DESCRIPTION
`BUILD_TESTING` is the CMake sanctioned option for the control of tests (c.f. https://cmake.org/cmake/help/latest/module/CTest.html).  Use the standard option to control the build of test targets.