### PR TITLE
build: hoist the policy settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.7)
+
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
+
 project(cmark VERSION 0.30.3)
 
 include("FindAsan.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(${CMAKE_VERSION} VERSION_GREATER "3.3")
-    cmake_policy(SET CMP0063 NEW)
-endif()
-
 set(LIBRARY "cmark")
 set(STATICLIBRARY "cmark_static")
 set(HEADERS


### PR DESCRIPTION
Policy settings may impact how `project` functions.  They should be set immediately after `cmake_minimum_required` (which implicitly sets policies).

Use the `POLICY` check to see if a policy is defined rather than using a version check.