### PR TITLE
build: correct typo and adjust command invocation

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,12 +10,12 @@ else()
 endif()
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
-  find_package(Python3 ${PYTHON_REQUIRED} COMPONENTS Interperter)
+  find_package(Python3 ${PYTHON_REQUIRED} COMPONENTS Interpreter)
 else()
   find_package(PythonInterp 3 ${PYTHON_REQUIRED})
-  set(Python_Interpreter_FOUND ${PYTHONINTERP_FOUND})
-  add_executable(Python::Interpreter IMPORTED)
-  set_target_properties(Python::Interpreter PROPERTIES
+  set(Python3_Interpreter_FOUND ${PYTHONINTERP_FOUND})
+  add_executable(Python3::Interpreter IMPORTED)
+  set_target_properties(Python3::Interpreter PROPERTIES
     IMPORTED_LOCATION ${PYTHON_EXECUTABLE})
 endif()
 
@@ -33,58 +33,58 @@ else(WIN32)
   set(ROUNDTRIP "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip.sh")
 endif(WIN32)
 
-IF (Python_Interpreter_FOUND)
+IF (Python3_Interpreter_FOUND)
 
-  add_test(html_normalization
-    $<Python::Interpreter> "-m" "doctest"
+  add_test(NAME html_normalization COMMAND
+    $<TARGET_FILE:Python3::Interpreter> "-m" "doctest"
     "${CMAKE_CURRENT_SOURCE_DIR}/normalize.py"
     )
 
   if (CMARK_SHARED)
-    add_test(spectest_library
-      $<Python::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
+    add_test(NAME spectest_library COMMAND
+      $<TARGET_FILE:Python3::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
       "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
       )
 
-    add_test(pathological_tests_library
-      $<Python::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/pathological_tests.py"
+    add_test(NAME pathological_tests_library COMMAND
+      $<TARGET_FILE:Python3::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/pathological_tests.py"
       "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
       )
 
-    add_test(roundtriptest_library
-      $<Python::Interpreter>
+    add_test(NAME roundtriptest_library COMMAND
+      $<TARGET_FILE:Python3::Interpreter>
       "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py"
       "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt"
       "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
       )
 
-    add_test(entity_library
-      $<Python::Interpreter>
+    add_test(NAME entity_library COMMAND
+      $<TARGET_FILE:Python3::Interpreter>
       "${CMAKE_CURRENT_SOURCE_DIR}/entity_tests.py"
       "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
       )
   endif()
 
-  add_test(spectest_executable
-    $<Python::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark"
+  add_test(NAME spectest_executable COMMAND
+    $<TARGET_FILE:Python3::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark"
     )
 
-  add_test(smartpuncttest_executable
-    $<Python::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/smart_punct.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark --smart"
+  add_test(NAME smartpuncttest_executable COMMAND
+    $<TARGET_FILE:Python3::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/smart_punct.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark --smart"
     )
 
-  add_test(regressiontest_executable
-    $<Python::Interpreter>
+  add_test(NAME regressiontest_executable COMMAND
+    $<TARGET_FILE:Python3::Interpreter>
     "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
     "${CMAKE_CURRENT_SOURCE_DIR}/regression.txt" "--program"
     "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark"
     )
 
-ELSE(Python_Interpreter_FOUND)
+ELSE(Python3_Interpreter_FOUND)
 
   message("\n*** A python 3 interpreter is required to run the spec tests.\n")
   add_test(skipping_spectests
     echo "Skipping spec tests, because no python 3 interpreter is available.")
 
-ENDIF(Python_Interpreter_FOUND)
+ENDIF(Python3_Interpreter_FOUND)
 


### PR DESCRIPTION
Use the proper generator expression for the python interpreter and adjust a typo in the component name.