### PR TITLE
build: clean up some test rules

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,48 +22,37 @@ endif()
 IF (Python3_Interpreter_FOUND)
 
   add_test(NAME html_normalization COMMAND
-    $<TARGET_FILE:Python3::Interpreter> "-m" "doctest"
-    "${CMAKE_CURRENT_SOURCE_DIR}/normalize.py"
+    "$<TARGET_FILE:Python3::Interpreter>" -m doctest "${CMAKE_CURRENT_SOURCE_DIR}/normalize.py"
     )
 
   if (CMARK_SHARED)
     add_test(NAME spectest_library COMMAND
-      $<TARGET_FILE:Python3::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
-      "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
+      "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" --no-normalize --spec "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" --library-dir "$<TARGET_FILE_DIR:cmark>"
       )
 
     add_test(NAME pathological_tests_library COMMAND
-      $<TARGET_FILE:Python3::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/pathological_tests.py"
-      "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
+      "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/pathological_tests.py" --library-dir "$<TARGET_FILE_DIR:cmark>"
       )
 
     add_test(NAME roundtriptest_library COMMAND
-      $<TARGET_FILE:Python3::Interpreter>
-      "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py"
-      "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt"
-      "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
+      "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py" --spec "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" --library-dir "$<TARGET_FILE_DIR:cmark>"
       )
 
     add_test(NAME entity_library COMMAND
-      $<TARGET_FILE:Python3::Interpreter>
-      "${CMAKE_CURRENT_SOURCE_DIR}/entity_tests.py"
-      "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
+      "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/entity_tests.py" --library-dir "$<TARGET_FILE_DIR:cmark>"
       )
   endif()
 
   add_test(NAME spectest_executable COMMAND
-    $<TARGET_FILE:Python3::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark"
+    "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" --no-normalize --spec "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" --program "$<TARGET_FILE:cmark_exe>"
     )
 
   add_test(NAME smartpuncttest_executable COMMAND
-    $<TARGET_FILE:Python3::Interpreter> "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/smart_punct.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark --smart"
+    "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" --no-normalize --spec "${CMAKE_CURRENT_SOURCE_DIR}/smart_punct.txt" --program "$<TARGET_FILE:cmark_exe> --smart"
     )
 
   add_test(NAME regressiontest_executable COMMAND
-    $<TARGET_FILE:Python3::Interpreter>
-    "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
-    "${CMAKE_CURRENT_SOURCE_DIR}/regression.txt" "--program"
-    "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark"
+    "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" --no-normalize --spec "${CMAKE_CURRENT_SOURCE_DIR}/regression.txt" --program "$<TARGET_FILE:cmark_exe>"
     )
 
 ELSE(Python3_Interpreter_FOUND)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,39 +21,47 @@ endif()
 
 IF (Python3_Interpreter_FOUND)
 
-  add_test(NAME html_normalization COMMAND
-    "$<TARGET_FILE:Python3::Interpreter>" -m doctest "${CMAKE_CURRENT_SOURCE_DIR}/normalize.py"
-    )
+  add_test(NAME html_normalization
+           COMMAND "$<TARGET_FILE:Python3::Interpreter>" -m doctest "${CMAKE_CURRENT_SOURCE_DIR}/normalize.py")
 
   if (CMARK_SHARED)
-    add_test(NAME spectest_library COMMAND
-      "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" --no-normalize --spec "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" --library-dir "$<TARGET_FILE_DIR:cmark>"
-      )
+    add_test(NAME spectest_library
+             COMMAND "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py"
+                                                           --no-normalize
+                                                           --spec "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt"
+                                                           --library-dir "$<TARGET_FILE_DIR:cmark>")
 
-    add_test(NAME pathological_tests_library COMMAND
-      "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/pathological_tests.py" --library-dir "$<TARGET_FILE_DIR:cmark>"
-      )
+    add_test(NAME pathological_tests_library
+             COMMAND "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/pathological_tests.py"
+                                                           --library-dir "$<TARGET_FILE_DIR:cmark>")
 
-    add_test(NAME roundtriptest_library COMMAND
-      "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py" --spec "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" --library-dir "$<TARGET_FILE_DIR:cmark>"
-      )
+    add_test(NAME roundtriptest_library
+             COMMAND "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py"
+                                                           --spec "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt"
+                                                           --library-dir "$<TARGET_FILE_DIR:cmark>")
 
-    add_test(NAME entity_library COMMAND
-      "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/entity_tests.py" --library-dir "$<TARGET_FILE_DIR:cmark>"
-      )
+    add_test(NAME entity_library
+             COMMAND "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/entity_tests.py"
+                                                           --library-dir "$<TARGET_FILE_DIR:cmark>")
   endif()
 
-  add_test(NAME spectest_executable COMMAND
-    "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" --no-normalize --spec "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" --program "$<TARGET_FILE:cmark_exe>"
-    )
+  add_test(NAME spectest_executable
+           COMMAND "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py"
+                                                         --no-normalize
+                                                         --spec "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt"
+                                                         --program "$<TARGET_FILE:cmark_exe>")
 
-  add_test(NAME smartpuncttest_executable COMMAND
-    "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" --no-normalize --spec "${CMAKE_CURRENT_SOURCE_DIR}/smart_punct.txt" --program "$<TARGET_FILE:cmark_exe> --smart"
-    )
+  add_test(NAME smartpuncttest_executable
+           COMMAND "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py"
+                                                         --no-normalize
+                                                         --spec "${CMAKE_CURRENT_SOURCE_DIR}/smart_punct.txt"
+                                                         --program "$<TARGET_FILE:cmark_exe> --smart")
 
-  add_test(NAME regressiontest_executable COMMAND
-    "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" --no-normalize --spec "${CMAKE_CURRENT_SOURCE_DIR}/regression.txt" --program "$<TARGET_FILE:cmark_exe>"
-    )
+  add_test(NAME regressiontest_executable
+           COMMAND "$<TARGET_FILE:Python3::Interpreter>" "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py"
+                                                         --no-normalize
+                                                         --spec "${CMAKE_CURRENT_SOURCE_DIR}/regression.txt"
+                                                         --program "$<TARGET_FILE:cmark_exe>")
 
 ELSE(Python3_Interpreter_FOUND)
 


### PR DESCRIPTION
Clean up the build rules by using generator expressions and reflowing some text to match the CMake documented style.