### PR TITLE
remove some compiler compatibility checks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -174,16 +174,10 @@ if(CMARK_SHARED OR CMARK_STATIC)
 endif()
 
 # Feature tests
-include(CheckIncludeFile)
 include(CheckCSourceCompiles)
-CHECK_INCLUDE_FILE(stdbool.h HAVE_STDBOOL_H)
 CHECK_C_SOURCE_COMPILES(
   "int main() { __builtin_expect(0,0); return 0; }"
   HAVE___BUILTIN_EXPECT)
-CHECK_C_SOURCE_COMPILES("
-  int f(void) __attribute__ (());
-  int main() { return 0; }
-" HAVE___ATTRIBUTE__)
 
 CONFIGURE_FILE(
   ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -5,10 +5,11 @@
  * see http://spec.commonmark.org/0.24/#phase-1-block-structure
  */
 
-#include <stdlib.h>
 #include <assert.h>
-#include <stdio.h>
 #include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "cmark_ctype.h"
 #include "config.h"

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1,11 +1,11 @@
-#include <stdarg.h>
-#include <string.h>
 #include <assert.h>
-#include <string.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
-#include <limits.h>
+#include <string.h>
 
 #include "config.h"
 #include "cmark_ctype.h"

--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -1,8 +1,9 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdint.h>
 #include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "config.h"
 #include "cmark.h"

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -5,23 +5,7 @@
 extern "C" {
 #endif
 
-#cmakedefine HAVE_STDBOOL_H
-
-#ifdef HAVE_STDBOOL_H
-  #include <stdbool.h>
-#elif !defined(__cplusplus)
-  typedef char bool;
-#endif
-
 #cmakedefine HAVE___BUILTIN_EXPECT
-
-#cmakedefine HAVE___ATTRIBUTE__
-
-#ifdef HAVE___ATTRIBUTE__
-  #define CMARK_ATTRIBUTE(list) __attribute__ (list)
-#else
-  #define CMARK_ATTRIBUTE(list)
-#endif
 
 #ifndef CMARK_INLINE
   #if defined(_MSC_VER) && !defined(__cplusplus)
@@ -29,44 +13,6 @@ extern "C" {
   #else
     #define CMARK_INLINE inline
   #endif
-#endif
-
-/* snprintf and vsnprintf fallbacks for MSVC before 2015,
-   due to Valentin Milea http://stackoverflow.com/questions/2915672/
-*/
-
-#if defined(_MSC_VER) && _MSC_VER < 1900
-
-#include <stdio.h>
-#include <stdarg.h>
-
-#define snprintf c99_snprintf
-#define vsnprintf c99_vsnprintf
-
-CMARK_INLINE int c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
-{
-    int count = -1;
-
-    if (size != 0)
-        count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
-    if (count == -1)
-        count = _vscprintf(format, ap);
-
-    return count;
-}
-
-CMARK_INLINE int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
-{
-    int count;
-    va_list ap;
-
-    va_start(ap, format);
-    count = c99_vsnprintf(outBuf, size, format, ap);
-    va_end(ap);
-
-    return count;
-}
-
 #endif
 
 #ifdef __cplusplus

--- a/src/html.c
+++ b/src/html.c
@@ -1,7 +1,9 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "cmark_ctype.h"
 #include "config.h"
 #include "cmark.h"

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -1,6 +1,7 @@
+#include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 
 #include "cmark_ctype.h"
 #include "config.h"

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include "config.h"

--- a/src/latex.c
+++ b/src/latex.c
@@ -1,7 +1,8 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "config.h"
 #include "cmark.h"

--- a/src/man.c
+++ b/src/man.c
@@ -1,7 +1,8 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "config.h"
 #include "cmark.h"

--- a/src/node.c
+++ b/src/node.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/node.h
+++ b/src/node.h
@@ -5,8 +5,9 @@
 extern "C" {
 #endif
 
-#include <stdio.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include "config.h"
 #include "cmark.h"

--- a/src/render.h
+++ b/src/render.h
@@ -5,7 +5,9 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <stdlib.h>
+
 #include "buffer.h"
 
 typedef enum { LITERAL, NORMAL, TITLE, URL } cmark_escaping;

--- a/src/xml.c
+++ b/src/xml.c
@@ -1,7 +1,8 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "config.h"
 #include "cmark.h"


### PR DESCRIPTION
`stdbool.h` is part of C99 however was not provided by Visual Studio 2013 until RTM [1]. Remove the check for the header and inline the include at the usage sites rather than relying on `config.h`.  VS2013 was EOL'ed Apr 9, 2019, with extended support ending Apr 9, 2024.

`HAVE___ATTRIBUTE__` was unused in the codebase and served no purpose.

Remove shims for `snprintf` and `vsnprintf` which were unavailable prior to VS2015.  As VS2013 is no longer serviced, this reduces complexity in the project.

[1] https://devblogs.microsoft.com/cppblog/c99-library-support-in-visual-studio-2013/