### PR TITLE
build: adjust the policy to silence warnings on MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 3.7)
 if(POLICY CMP0063)
   cmake_policy(SET CMP0063 NEW)
 endif()
+if(POLICY CMP0092)
+  cmake_policy(SET CMP0092 NEW)
+endif()
 
 project(cmark VERSION 0.30.3)
 


### PR DESCRIPTION
CMake 3.15+ remove `/W3` from the language flags under MSVC with CMP0092.  Set the policy to new to avoid the D9025 warning.