### PR TITLE
clean up C4244 warnings on MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_compile_options($<$<CONFIG:Debug>:-DCMARK_DEBUG_NODES>)
 # so that CMark may be used in projects with non-C languages.
 function(cmark_add_compile_options target)
   if(MSVC)
-    target_compile_options(${target} PRIVATE /W4 /wd4706)
+    target_compile_options(${target} PRIVATE /W4 /wd4706 /we4244)
     if(MSVC_VERSION LESS 1800)
       target_compile_options(${target} PRIVATE /TP)
     endif()

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -606,7 +606,7 @@ static void S_parser_feed(cmark_parser *parser, const unsigned char *buffer,
       process = true;
     }
 
-    chunk_len = (eol - buffer);
+    chunk_len = (bufsize_t)(eol - buffer);
     if (process) {
       if (parser->linebuf.size > 0) {
         cmark_strbuf_put(&parser->linebuf, buffer, chunk_len);
@@ -993,7 +993,7 @@ static void open_new_blocks(cmark_parser *parser, cmark_node **container,
         hashpos++;
       }
 
-      (*container)->as.heading.level = level;
+      (*container)->as.heading.level = (int8_t)level;
       (*container)->as.heading.setext = false;
       (*container)->as.heading.internal_offset = matched;
 
@@ -1003,7 +1003,7 @@ static void open_new_blocks(cmark_parser *parser, cmark_node **container,
                              parser->first_nonspace + 1);
       (*container)->as.code.fenced = true;
       (*container)->as.code.fence_char = peek_at(input, parser->first_nonspace);
-      (*container)->as.code.fence_length = (matched > 255) ? 255 : matched;
+      (*container)->as.code.fence_length = (matched > 255) ? 255 : (uint8_t)matched;
       (*container)->as.code.fence_offset =
           (int8_t)(parser->first_nonspace - parser->offset);
       (*container)->as.code.info = NULL;
@@ -1031,7 +1031,7 @@ static void open_new_blocks(cmark_parser *parser, cmark_node **container,
       if (has_content) {
 
         (*container)->type = (uint16_t)CMARK_NODE_HEADING;
-        (*container)->as.heading.level = lev;
+        (*container)->as.heading.level = (int8_t)lev;
         (*container)->as.heading.setext = true;
         S_advance_offset(parser, input, input->len - 1 - parser->offset, false);
       }

--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -49,18 +49,18 @@ static CMARK_INLINE void outc(cmark_renderer *renderer, cmark_escaping escape,
          (renderer->begin_content && (c == '.' || c == ')') && follows_digit &&
           (nextc == 0 || cmark_isspace(nextc))))) ||
        (escape == URL &&
-        (c == '`' || c == '<' || c == '>' || cmark_isspace(c) || c == '\\' ||
+        (c == '`' || c == '<' || c == '>' || cmark_isspace((char)c) || c == '\\' ||
          c == ')' || c == '(')) ||
        (escape == TITLE &&
         (c == '`' || c == '<' || c == '>' || c == '"' || c == '\\')));
 
   if (needs_escaping) {
-    if (escape == URL && cmark_isspace(c)) {
+    if (escape == URL && cmark_isspace((char)c)) {
       // use percent encoding for spaces
       snprintf(encoded, ENCODED_SIZE, "%%%2X", c);
       cmark_strbuf_puts(renderer->buffer, encoded);
       renderer->column += 3;
-    } else if (cmark_ispunct(c)) {
+    } else if (cmark_ispunct((char)c)) {
       cmark_render_ascii(renderer, "\\");
       cmark_render_code_point(renderer, c);
     } else { // render as entity

--- a/src/node.c
+++ b/src/node.c
@@ -348,7 +348,7 @@ int cmark_node_set_heading_level(cmark_node *node, int level) {
 
   switch (node->type) {
   case CMARK_NODE_HEADING:
-    node->as.heading.level = level;
+    node->as.heading.level = (int8_t)level;
     return 1;
 
   default:

--- a/src/render.c
+++ b/src/render.c
@@ -96,13 +96,13 @@ static void S_out(cmark_renderer *renderer, const char *source, bool wrap,
         // we need to escape a potential list marker after
         // a digit:
         renderer->begin_content =
-            renderer->begin_content && cmark_isdigit(c) == 1;
+            renderer->begin_content && cmark_isdigit((char)c) == 1;
       }
     } else {
       (renderer->outc)(renderer, escape, c, nextc);
       renderer->begin_line = false;
       renderer->begin_content =
-          renderer->begin_content && cmark_isdigit(c) == 1;
+          renderer->begin_content && cmark_isdigit((char)c) == 1;
     }
 
     // If adding the character went beyond width, look for an


### PR DESCRIPTION
C4244 appertains to implicit truncation of integer values [1]. Theoretically, these warnings could be detected using `-fsanitize=implicit-unsigned-integer-truncation` and `-fsanitize=implicit-signed-integer-truncation` as well as statically using `-Werror=implicit-int-conversion`.

[1] https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244?view=msvc-170