### PR TITLE
clean up C4267 warnings on MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_compile_options($<$<CONFIG:Debug>:-DCMARK_DEBUG_NODES>)
 # so that CMark may be used in projects with non-C languages.
 function(cmark_add_compile_options target)
   if(MSVC)
-    target_compile_options(${target} PRIVATE /W4 /wd4706 /we4244)
+    target_compile_options(${target} PRIVATE /W4 /wd4706 /we4244 /we4267)
     if(MSVC_VERSION LESS 1800)
       target_compile_options(${target} PRIVATE /TP)
     endif()

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -577,7 +577,7 @@ static void S_parser_feed(cmark_parser *parser, const unsigned char *buffer,
   if (len > UINT_MAX - parser->total_size)
     parser->total_size = UINT_MAX;
   else
-    parser->total_size += len;
+    parser->total_size += (int)len;
 
   // Skip UTF-8 BOM if present; see #334
   if (parser->line_number == 0 && parser->column == 0 && len >= 3 &&

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -95,7 +95,7 @@ void cmark_strbuf_set(cmark_strbuf *buf, const unsigned char *data,
 
 void cmark_strbuf_sets(cmark_strbuf *buf, const char *string) {
   cmark_strbuf_set(buf, (const unsigned char *)string,
-                   string ? strlen(string) : 0);
+                   string ? (bufsize_t)strlen(string) : 0);
 }
 
 void cmark_strbuf_putc(cmark_strbuf *buf, int c) {
@@ -116,7 +116,7 @@ void cmark_strbuf_put(cmark_strbuf *buf, const unsigned char *data,
 }
 
 void cmark_strbuf_puts(cmark_strbuf *buf, const char *string) {
-  cmark_strbuf_put(buf, (const unsigned char *)string, strlen(string));
+  cmark_strbuf_put(buf, (const unsigned char *)string, (bufsize_t)strlen(string));
 }
 
 void cmark_strbuf_copy_cstr(char *data, bufsize_t datasize,

--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -67,7 +67,7 @@ static CMARK_INLINE void outc(cmark_renderer *renderer, cmark_escaping escape,
     } else { // render as entity
       snprintf(encoded, ENCODED_SIZE, "&#%d;", c);
       cmark_strbuf_puts(renderer->buffer, encoded);
-      renderer->column += strlen(encoded);
+      renderer->column += (int)strlen(encoded);
     }
   } else {
     cmark_render_code_point(renderer, c);
@@ -230,7 +230,7 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       snprintf(listmarker, LISTMARKER_SIZE, "%d%s%s", list_number,
                list_delim == CMARK_PAREN_DELIM ? ")" : ".",
                list_number < 10 ? "  " : " ");
-      marker_width = strlen(listmarker);
+      marker_width = (bufsize_t)strlen(listmarker);
     }
     if (entering) {
       if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {

--- a/src/html.c
+++ b/src/html.c
@@ -281,12 +281,12 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
       if (node->as.link.url && ((options & CMARK_OPT_UNSAFE) ||
                                 !(_scan_dangerous_url(node->as.link.url)))) {
         houdini_escape_href(html, node->as.link.url,
-                            strlen((char *)node->as.link.url));
+                            (bufsize_t)strlen((char *)node->as.link.url));
       }
       if (node->as.link.title) {
         cmark_strbuf_puts(html, "\" title=\"");
         escape_html(html, node->as.link.title,
-                    strlen((char *)node->as.link.title));
+                    (bufsize_t)strlen((char *)node->as.link.title));
       }
       cmark_strbuf_puts(html, "\">");
     } else {
@@ -300,7 +300,7 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
       if (node->as.link.url && ((options & CMARK_OPT_UNSAFE) ||
                                 !(_scan_dangerous_url(node->as.link.url)))) {
         houdini_escape_href(html, node->as.link.url,
-                            strlen((char *)node->as.link.url));
+                            (bufsize_t)strlen((char *)node->as.link.url));
       }
       cmark_strbuf_puts(html, "\" alt=\"");
       state->plain = node;
@@ -308,7 +308,7 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
       if (node->as.link.title) {
         cmark_strbuf_puts(html, "\" title=\"");
         escape_html(html, node->as.link.title,
-                    strlen((char *)node->as.link.title));
+                    (bufsize_t)strlen((char *)node->as.link.title));
       }
 
       cmark_strbuf_puts(html, "\" />");

--- a/src/references.c
+++ b/src/references.c
@@ -63,9 +63,9 @@ void cmark_reference_create(cmark_reference_map *map, cmark_chunk *label,
   ref->next = map->refs;
 
   if (ref->url != NULL)
-    ref->size += strlen((char*)ref->url);
+    ref->size += (int)strlen((char*)ref->url);
   if (ref->title != NULL)
-    ref->size += strlen((char*)ref->title);
+    ref->size += (int)strlen((char*)ref->title);
 
   map->refs = ref;
   map->size++;

--- a/src/render.c
+++ b/src/render.c
@@ -20,7 +20,7 @@ static CMARK_INLINE void S_blankline(cmark_renderer *renderer) {
 
 static void S_out(cmark_renderer *renderer, const char *source, bool wrap,
                   cmark_escaping escape) {
-  int length = strlen(source);
+  int length = (int)strlen(source);
   unsigned char nextc;
   int32_t c;
   int i = 0;

--- a/src/xml.c
+++ b/src/xml.c
@@ -75,7 +75,7 @@ static void escape_xml(cmark_strbuf *ob, const unsigned char *src,
 
 static void escape_xml_str(cmark_strbuf *dest, const unsigned char *source) {
   if (source)
-    escape_xml(dest, source, strlen((char *)source));
+    escape_xml(dest, source, (bufsize_t)strlen((char *)source));
 }
 
 struct render_state {


### PR DESCRIPTION
C4267 appertains to truncation of `size_t` values to narrower types. Some of these should be possible to catch via clang as well through checks for narrowing.