### PR TITLE
replace usage of `CMARK_INLINE` with `inline`

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -41,7 +41,7 @@ static bool S_last_line_checked(const cmark_node *node) {
   return (node->flags & CMARK_NODE__LAST_LINE_CHECKED) != 0;
 }
 
-static CMARK_INLINE cmark_node_type S_type(const cmark_node *node) {
+static inline cmark_node_type S_type(const cmark_node *node) {
   return (cmark_node_type)node->type;
 }
 
@@ -56,11 +56,11 @@ static void S_set_last_line_checked(cmark_node *node) {
   node->flags |= CMARK_NODE__LAST_LINE_CHECKED;
 }
 
-static CMARK_INLINE bool S_is_line_end_char(char c) {
+static inline bool S_is_line_end_char(char c) {
   return (c == '\n' || c == '\r');
 }
 
-static CMARK_INLINE bool S_is_space_or_tab(char c) {
+static inline bool S_is_space_or_tab(char c) {
   return (c == ' ' || c == '\t');
 }
 
@@ -156,21 +156,21 @@ static bool is_blank(cmark_strbuf *s, bufsize_t offset) {
   return true;
 }
 
-static CMARK_INLINE bool can_contain(cmark_node_type parent_type,
-                                     cmark_node_type child_type) {
+static inline bool can_contain(cmark_node_type parent_type,
+                               cmark_node_type child_type) {
   return (parent_type == CMARK_NODE_DOCUMENT ||
           parent_type == CMARK_NODE_BLOCK_QUOTE ||
           parent_type == CMARK_NODE_ITEM ||
           (parent_type == CMARK_NODE_LIST && child_type == CMARK_NODE_ITEM));
 }
 
-static CMARK_INLINE bool accepts_lines(cmark_node_type block_type) {
+static inline bool accepts_lines(cmark_node_type block_type) {
   return (block_type == CMARK_NODE_PARAGRAPH ||
           block_type == CMARK_NODE_HEADING ||
           block_type == CMARK_NODE_CODE_BLOCK);
 }
 
-static CMARK_INLINE bool contains_inlines(cmark_node_type block_type) {
+static inline bool contains_inlines(cmark_node_type block_type) {
   return (block_type == CMARK_NODE_PARAGRAPH ||
           block_type == CMARK_NODE_HEADING);
 }

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -31,7 +31,7 @@ void cmark_strbuf_init(cmark_mem *mem, cmark_strbuf *buf,
     cmark_strbuf_grow(buf, initial_size);
 }
 
-static CMARK_INLINE void S_strbuf_grow_by(cmark_strbuf *buf, bufsize_t add) {
+static inline void S_strbuf_grow_by(cmark_strbuf *buf, bufsize_t add) {
   cmark_strbuf_grow(buf, buf->size + add);
 }
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -52,7 +52,7 @@ void cmark_strbuf_copy_cstr(char *data, bufsize_t datasize,
                             const cmark_strbuf *buf);
 
 /*
-static CMARK_INLINE const char *cmark_strbuf_cstr(const cmark_strbuf *buf) {
+static inline const char *cmark_strbuf_cstr(const cmark_strbuf *buf) {
  return (char *)buf->ptr;
 }
 */

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -17,19 +17,19 @@ typedef struct {
 } cmark_chunk;
 
 // NOLINTNEXTLINE(clang-diagnostic-unused-function)
-static CMARK_INLINE void cmark_chunk_free(cmark_chunk *c) {
+static inline void cmark_chunk_free(cmark_chunk *c) {
   c->data = NULL;
   c->len = 0;
 }
 
-static CMARK_INLINE void cmark_chunk_ltrim(cmark_chunk *c) {
+static inline void cmark_chunk_ltrim(cmark_chunk *c) {
   while (c->len && cmark_isspace(c->data[0])) {
     c->data++;
     c->len--;
   }
 }
 
-static CMARK_INLINE void cmark_chunk_rtrim(cmark_chunk *c) {
+static inline void cmark_chunk_rtrim(cmark_chunk *c) {
   while (c->len > 0) {
     if (!cmark_isspace(c->data[c->len - 1]))
       break;
@@ -39,29 +39,29 @@ static CMARK_INLINE void cmark_chunk_rtrim(cmark_chunk *c) {
 }
 
 // NOLINTNEXTLINE(clang-diagnostic-unused-function)
-static CMARK_INLINE void cmark_chunk_trim(cmark_chunk *c) {
+static inline void cmark_chunk_trim(cmark_chunk *c) {
   cmark_chunk_ltrim(c);
   cmark_chunk_rtrim(c);
 }
 
 // NOLINTNEXTLINE(clang-diagnostic-unused-function)
-static CMARK_INLINE bufsize_t cmark_chunk_strchr(cmark_chunk *ch, int c,
-                                                 bufsize_t offset) {
+static inline bufsize_t cmark_chunk_strchr(cmark_chunk *ch, int c,
+                                           bufsize_t offset) {
   const unsigned char *p =
       (unsigned char *)memchr(ch->data + offset, c, ch->len - offset);
   return p ? (bufsize_t)(p - ch->data) : ch->len;
 }
 
 // NOLINTNEXTLINE(clang-diagnostic-unused-function)
-static CMARK_INLINE cmark_chunk cmark_chunk_literal(const char *data) {
+static inline cmark_chunk cmark_chunk_literal(const char *data) {
   bufsize_t len = data ? (bufsize_t)strlen(data) : 0;
   cmark_chunk c = {(unsigned char *)data, len};
   return c;
 }
 
 // NOLINTNEXTLINE(clang-diagnostic-unused-function)
-static CMARK_INLINE cmark_chunk cmark_chunk_dup(const cmark_chunk *ch,
-                                                bufsize_t pos, bufsize_t len) {
+static inline cmark_chunk cmark_chunk_dup(const cmark_chunk *ch, bufsize_t pos,
+                                          bufsize_t len) {
   cmark_chunk c = {ch->data + pos, len};
   return c;
 }

--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -22,8 +22,8 @@
 
 // Functions to convert cmark_nodes to commonmark strings.
 
-static CMARK_INLINE void outc(cmark_renderer *renderer, cmark_escaping escape,
-                              int32_t c, unsigned char nextc) {
+static inline void outc(cmark_renderer *renderer, cmark_escaping escape,
+                        int32_t c, unsigned char nextc) {
   bool needs_escaping = false;
   bool follows_digit =
       renderer->buffer->size > 0 &&

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -7,14 +7,6 @@ extern "C" {
 
 #cmakedefine HAVE___BUILTIN_EXPECT
 
-#ifndef CMARK_INLINE
-  #if defined(_MSC_VER) && !defined(__cplusplus)
-    #define CMARK_INLINE __inline
-  #else
-    #define CMARK_INLINE inline
-  #endif
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/html.c
+++ b/src/html.c
@@ -21,7 +21,7 @@ static void escape_html(cmark_strbuf *dest, const unsigned char *source,
   houdini_escape_html0(dest, source, length, 0);
 }
 
-static CMARK_INLINE void cr(cmark_strbuf *html) {
+static inline void cr(cmark_strbuf *html) {
   if (html->size && html->ptr[html->size - 1] != '\n')
     cmark_strbuf_putc(html, '\n');
 }

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -71,7 +71,7 @@ typedef struct {
   bool no_link_openers;
 } subject;
 
-static CMARK_INLINE bool S_is_line_end_char(char c) {
+static inline bool S_is_line_end_char(char c) {
   return (c == '\n' || c == '\r');
 }
 
@@ -85,8 +85,8 @@ static void subject_from_buf(cmark_mem *mem, int line_number, int block_offset, 
 static bufsize_t subject_find_special_char(subject *subj, int options);
 
 // Create an inline with a literal string value.
-static CMARK_INLINE cmark_node *make_literal(subject *subj, cmark_node_type t,
-                                             int start_column, int end_column) {
+static inline cmark_node *make_literal(subject *subj, cmark_node_type t,
+                                       int start_column, int end_column) {
   cmark_node *e = (cmark_node *)subj->mem->calloc(1, sizeof(*e));
   e->mem = subj->mem;
   e->type = (uint16_t)t;
@@ -98,7 +98,7 @@ static CMARK_INLINE cmark_node *make_literal(subject *subj, cmark_node_type t,
 }
 
 // Create an inline with no value.
-static CMARK_INLINE cmark_node *make_simple(cmark_mem *mem, cmark_node_type t) {
+static inline cmark_node *make_simple(cmark_mem *mem, cmark_node_type t) {
   cmark_node *e = (cmark_node *)mem->calloc(1, sizeof(*e));
   e->mem = mem;
   e->type = t;
@@ -180,9 +180,9 @@ static unsigned char *cmark_clean_autolink(cmark_mem *mem, cmark_chunk *url,
   return cmark_strbuf_detach(&buf);
 }
 
-static CMARK_INLINE cmark_node *make_autolink(subject *subj,
-                                              int start_column, int end_column,
-                                              cmark_chunk url, int is_email) {
+static inline cmark_node *make_autolink(subject *subj, int start_column,
+                                        int end_column, cmark_chunk url,
+                                        int is_email) {
   cmark_node *link = make_simple(subj->mem, CMARK_NODE_LINK);
   link->as.link.url = cmark_clean_autolink(subj->mem, &url, is_email);
   link->as.link.title = NULL;
@@ -213,28 +213,28 @@ static void subject_from_buf(cmark_mem *mem, int line_number, int block_offset, 
   e->no_link_openers = true;
 }
 
-static CMARK_INLINE int isbacktick(int c) { return (c == '`'); }
+static inline int isbacktick(int c) { return (c == '`'); }
 
-static CMARK_INLINE unsigned char peek_char(subject *subj) {
+static inline unsigned char peek_char(subject *subj) {
   // NULL bytes should have been stripped out by now.  If they're
   // present, it's a programming error:
   assert(!(subj->pos < subj->input.len && subj->input.data[subj->pos] == 0));
   return (subj->pos < subj->input.len) ? subj->input.data[subj->pos] : 0;
 }
 
-static CMARK_INLINE unsigned char peek_at(subject *subj, bufsize_t pos) {
+static inline unsigned char peek_at(subject *subj, bufsize_t pos) {
   return subj->input.data[pos];
 }
 
 // Return true if there are more characters in the subject.
-static CMARK_INLINE int is_eof(subject *subj) {
+static inline int is_eof(subject *subj) {
   return (subj->pos >= subj->input.len);
 }
 
 // Advance the subject.  Doesn't check for eof.
 #define advance(subj) (subj)->pos += 1
 
-static CMARK_INLINE bool skip_spaces(subject *subj) {
+static inline bool skip_spaces(subject *subj) {
   bool skipped = false;
   while (peek_char(subj) == ' ' || peek_char(subj) == '\t') {
     advance(subj);
@@ -243,7 +243,7 @@ static CMARK_INLINE bool skip_spaces(subject *subj) {
   return skipped;
 }
 
-static CMARK_INLINE bool skip_line_end(subject *subj) {
+static inline bool skip_line_end(subject *subj) {
   bool seen_line_end_char = false;
   if (peek_char(subj) == '\r') {
     advance(subj);
@@ -257,7 +257,7 @@ static CMARK_INLINE bool skip_line_end(subject *subj) {
 }
 
 // Take characters while a predicate holds, and return a string.
-static CMARK_INLINE cmark_chunk take_while(subject *subj, int (*f)(int)) {
+static inline cmark_chunk take_while(subject *subj, int (*f)(int)) {
   unsigned char c;
   bufsize_t startpos = subj->pos;
   bufsize_t len = 0;

--- a/src/latex.c
+++ b/src/latex.c
@@ -18,8 +18,8 @@
 #define BLANKLINE() renderer->blankline(renderer)
 #define LIST_NUMBER_STRING_SIZE 20
 
-static CMARK_INLINE void outc(cmark_renderer *renderer, cmark_escaping escape,
-                              int32_t c, unsigned char nextc) {
+static inline void outc(cmark_renderer *renderer, cmark_escaping escape,
+                        int32_t c, unsigned char nextc) {
   if (escape == LITERAL) {
     cmark_render_code_point(renderer, c);
     return;

--- a/src/node.c
+++ b/src/node.c
@@ -7,7 +7,7 @@
 
 static void S_node_unlink(cmark_node *node);
 
-static CMARK_INLINE bool S_is_block(cmark_node *node) {
+static inline bool S_is_block(cmark_node *node) {
   if (node == NULL) {
     return false;
   }
@@ -15,7 +15,7 @@ static CMARK_INLINE bool S_is_block(cmark_node *node) {
          node->type <= CMARK_NODE_LAST_BLOCK;
 }
 
-static CMARK_INLINE bool S_is_inline(cmark_node *node) {
+static inline bool S_is_inline(cmark_node *node) {
   if (node == NULL) {
     return false;
   }

--- a/src/render.c
+++ b/src/render.c
@@ -6,13 +6,13 @@
 #include "node.h"
 #include "cmark_ctype.h"
 
-static CMARK_INLINE void S_cr(cmark_renderer *renderer) {
+static inline void S_cr(cmark_renderer *renderer) {
   if (renderer->need_cr < 1) {
     renderer->need_cr = 1;
   }
 }
 
-static CMARK_INLINE void S_blankline(cmark_renderer *renderer) {
+static inline void S_blankline(cmark_renderer *renderer) {
   if (renderer->need_cr < 2) {
     renderer->need_cr = 2;
   }

--- a/src/xml.c
+++ b/src/xml.c
@@ -83,7 +83,7 @@ struct render_state {
   int indent;
 };
 
-static CMARK_INLINE void indent(struct render_state *state) {
+static inline void indent(struct render_state *state) {
   int i;
   for (i = 0; i < state->indent && i < MAX_INDENT; i++) {
     cmark_strbuf_putc(state->xml, ' ');


### PR DESCRIPTION
Modern versions of MSVC (2015+) support most of the C99 standard, including the `inline` keyword.  Avoid the vendor extension `__inline` and use the ISO standard spelling.