### PR TITLE
squelch C4232 warnings on MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ add_compile_options($<$<CONFIG:Debug>:-DCMARK_DEBUG_NODES>)
 # so that CMark may be used in projects with non-C languages.
 function(cmark_add_compile_options target)
   if(MSVC)
-    target_compile_options(${target} PRIVATE /W4 /wd4706 /we4244 /we4267)
+    target_compile_options(${target} PRIVATE /W4 /wd4706 /wd4232 /we4244 /we4267)
     target_compile_definitions(${target} PRIVATE _CRT_SECURE_NO_WARNINGS)
   else()
     target_compile_options(${target} PRIVATE


### PR DESCRIPTION
C4232 appertains to the identity of dllimported functions [1]. The address of dllimport'ed functions are not guaranteed to maintain identity as the address will be the address of the IAT thunk, which is module specific.  Two modules which bind to the same implementation may have different addresses. However, since the use of this is for `free`, it should be relatively safe as we do not expect to perform pointer identity comparisons.

[1] https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4232?view=msvc-170