### PR TITLE
build: hoist the C visibility settings to top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ if(NOT MSVC)
   set(CMAKE_C_EXTENSIONS NO)
 endif()
 
+# -fvisibility=hidden
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # The Linux modules distributed with CMake add "-rdynamic" to the build flags

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,10 +59,6 @@ elseif (CMARK_SHARED)
   target_link_libraries(${PROGRAM} ${LIBRARY})
 endif()
 
-# -fvisibility=hidden
-set(CMAKE_C_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
-
 if (CMARK_SHARED)
   add_library(${LIBRARY} SHARED ${LIBRARY_SOURCES})
   cmark_add_compile_options(${LIBRARY})


### PR DESCRIPTION
These settings are applied globally, hoist them to the top level of the project to make them easier to spot.