### PR TITLE
build: hoist the CMake module inclusion to the top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,19 @@ if(CMAKE_BUILD_TYPE MATCHES "asan|ubsan")
   list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
   include(FindAsan)
 endif()
-include(GNUInstallDirs)
+
+# Include module for functions
+# - 'write_basic_package_version_file'
+# - 'configure_package_config_file'
+include(CMakePackageConfigHelpers)
 include(CTest)
+include(GenerateExportHeader)
+include(GNUInstallDirs)
+
+if(NOT MSVC OR CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
+  set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
+  include(InstallRequiredSystemLibraries)
+endif()
 
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "Do not build in-source.\nPlease remove CMakeCache.txt and the CMakeFiles/ directory.\nThen: mkdir build ; cd build ; cmake .. ; make")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,9 +45,6 @@ set(PROGRAM_SOURCES main.c)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmark_version.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/cmark_version.h)
 
-include(GNUInstallDirs)
-include (GenerateExportHeader)
-
 add_executable(${PROGRAM} ${PROGRAM_SOURCES})
 cmark_add_compile_options(${PROGRAM})
 set_target_properties(${PROGRAM} PROPERTIES
@@ -116,11 +113,6 @@ if (MSVC)
     APPEND PROPERTY LINK_FLAGS /INCREMENTAL:NO)
 endif(MSVC)
 
-if(NOT MSVC OR CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
-  set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
-  include(InstallRequiredSystemLibraries)
-endif()
-
 install(TARGETS ${PROGRAM} ${CMARK_INSTALL}
   EXPORT cmark-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -141,10 +133,6 @@ if(CMARK_SHARED OR CMARK_STATIC)
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 
-  # Include module for functions
-  # - 'write_basic_package_version_file'
-  # - 'configure_package_config_file'
-  include(CMakePackageConfigHelpers)
   # generate cmark-config.cmake and cmark-config-version.cmake files
   configure_package_config_file(
     "cmarkConfig.cmake.in"


### PR DESCRIPTION
This ensures that we do not double process the various modules and easily allows identification of what is used in the build.