### PR TITLE
test: simplify test execution environment handling

### DIFF
--- a/api_test/CMakeLists.txt
+++ b/api_test/CMakeLists.txt
@@ -10,9 +10,7 @@ target_link_libraries(api_test PRIVATE
 
 add_test(NAME api_test COMMAND api_test)
 if(WIN32)
-  file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR}/src WIN_DLL_DIR)
-  set(NEWPATH "${WIN_DLL_DIR};$ENV{PATH}")
-  string(REPLACE ";" "\\;" NEWPATH "${NEWPATH}")
-  set_tests_properties(api_test PROPERTIES ENVIRONMENT "PATH=${NEWPATH}")
+  set_tests_properties(api_test PROPERTIES
+    ENVIRONMENT "PATH=$<TARGET_FILE_DIR:cmark>$<SEMICOLON>$ENV{PATH}")
 endif()
 


### PR DESCRIPTION
Use generator expressions to compute the new path and avoid translations. This reduces complexity in the build and allows for a different build layout.