### PR TITLE
workflows: Fix valgrind installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install valgrind
       run: |
+         sudo apt update
          sudo apt install -y valgrind
     - name: Build and test
       run: |


### PR DESCRIPTION
Run `apt update` before installing.