### PR TITLE
Introduce `cmake_node_convert_type`

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -911,6 +911,62 @@ static void test_feed_across_line_ending(test_batch_runner *runner) {
   cmark_node_free(document);
 }
 
+static void sub_document(test_batch_runner *runner) {
+  cmark_node *doc = cmark_node_new(CMARK_NODE_DOCUMENT);
+  cmark_node *list = cmark_node_new(CMARK_NODE_LIST);
+  OK(runner, cmark_node_append_child(doc, list), "list");
+
+  {
+    static const char markdown[] =
+      "Hello &ldquo; <http://www.google.com>\n";
+    cmark_node *sub_doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
+    OK(runner, cmake_node_convert_type(sub_doc, CMARK_NODE_ITEM), "convert0");
+    OK(runner, cmark_node_append_child(list, sub_doc), "append0");
+  }
+
+  {
+    static const char markdown[] =
+      "Bye &ldquo; <http://www.geocities.com>\n";
+    cmark_node *sub_doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
+    OK(runner, cmake_node_convert_type(sub_doc, CMARK_NODE_ITEM), "convert1");
+    OK(runner, cmark_node_append_child(list, sub_doc), "append1");
+  }
+
+  char *xml = cmark_render_xml(doc, CMARK_OPT_DEFAULT);
+  STR_EQ(runner, xml, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                      "<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n"
+                      "<document xmlns=\"http://commonmark.org/xml/1.0\">\n"
+                      "  <list type=\"bullet\" tight=\"false\">\n"
+                      "    <item>\n"
+                      "      <paragraph>\n"
+                      "        <text xml:space=\"preserve\">Hello “ </text>\n"
+                      "        <link destination=\"http://www.google.com\">\n"
+                      "          <text xml:space=\"preserve\">http://www.google.com</text>\n"
+                      "        </link>\n"
+                      "      </paragraph>\n"
+                      "    </item>\n"
+                      "    <item>\n"
+                      "      <paragraph>\n"
+                      "        <text xml:space=\"preserve\">Bye “ </text>\n"
+                      "        <link destination=\"http://www.geocities.com\">\n"
+                      "          <text xml:space=\"preserve\">http://www.geocities.com</text>\n"
+                      "        </link>\n"
+                      "      </paragraph>\n"
+                      "    </item>\n"
+                      "  </list>\n"
+                      "</document>\n",
+         "nested document XML is as expected");
+  free(xml);
+
+  char *cmark = cmark_render_commonmark(doc, CMARK_OPT_DEFAULT, 0);
+  STR_EQ(runner, cmark, "  - Hello “ <http://www.google.com>\n"
+                        "\n"
+                        "  - Bye “ <http://www.geocities.com>\n",
+         "nested document CommonMark is as expected");
+
+  cmark_node_free(doc);
+}
+
 static void source_pos(test_batch_runner *runner) {
   static const char markdown[] =
     "# Hi *there*.\n"
@@ -1093,6 +1149,7 @@ int main(void) {
   test_cplusplus(runner);
   test_safe(runner);
   test_feed_across_line_ending(runner);
+  sub_document(runner);
   source_pos(runner);
   source_pos_inlines(runner);
   ref_source_pos(runner);

--- a/src/cmark.h
+++ b/src/cmark.h
@@ -125,6 +125,16 @@ CMARK_EXPORT cmark_node *cmark_node_new_with_mem(cmark_node_type type,
  */
 CMARK_EXPORT void cmark_node_free(cmark_node *node);
 
+/** Convert a node from one type to another
+ *
+ * It is required that the new type allows the same type of children (or broader) as the old type.
+ *
+ * Returns 1 on success, 0 on failure. On failure the node is left as-is.
+ *
+ * O(1)
+ */
+CMARK_EXPORT int cmake_node_convert_type(cmark_node *node, cmark_node_type type);
+
 /**
  * ## Tree Traversal
  */

--- a/src/node.c
+++ b/src/node.c
@@ -110,11 +110,8 @@ static bool S_can_contain(cmark_node *node, cmark_node *child) {
     S_compute_allowed_child(node->type));
 }
 
-cmark_node *cmark_node_new_with_mem(cmark_node_type type, cmark_mem *mem) {
-  cmark_node *node = (cmark_node *)mem->calloc(1, sizeof(*node));
-  node->mem = mem;
-  node->type = (uint16_t)type;
-
+// Initialize the type-specific fields of a node
+static void S_cmark_node_init(cmark_node * node) {
   switch (node->type) {
   case CMARK_NODE_HEADING:
     node->as.heading.level = 1;
@@ -131,6 +128,15 @@ cmark_node *cmark_node_new_with_mem(cmark_node_type type, cmark_mem *mem) {
   default:
     break;
   }
+
+}
+
+cmark_node *cmark_node_new_with_mem(cmark_node_type type, cmark_mem *mem) {
+  cmark_node *node = (cmark_node *)mem->calloc(1, sizeof(*node));
+  node->mem = mem;
+  node->type = (uint16_t)type;
+
+  S_cmark_node_init(node);
 
   return node;
 }

--- a/src/node.c
+++ b/src/node.c
@@ -175,6 +175,23 @@ cmark_node *cmark_node_new(cmark_node_type type) {
   return cmark_node_new_with_mem(type, &DEFAULT_MEM_ALLOCATOR);
 }
 
+int cmake_node_convert_type(cmark_node *node, cmark_node_type type) {
+  // Only need to validate children if we have any
+  if (node->first_child) {
+    enum node_class
+      old = S_compute_allowed_child(node->type),
+      new = S_compute_allowed_child(type);
+    if (!S_node_class_le(old, new))
+      return 0;
+  }
+
+  // Success path
+  S_cmark_node_deinit(node);
+  node->type = type;
+  S_cmark_node_init(node);
+  return 1;
+}
+
 // Free a cmark_node list and any children.
 static void S_free_nodes(cmark_node *e) {
   cmark_mem *mem = e->mem;


### PR DESCRIPTION
This is useful when constructing ASTs that contain a mix of computed and parsed data. "sub documents" that are parsed have a single root document node, and rather than having to extract its children, those can be placed as-is in a larger parse tree.