### PR TITLE
build: Tell cmake to set 'rpath'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,21 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+if (DEFINED CMAKE_INSTALL_RPATH)
+  set(Base_rpath "${CMAKE_INSTALL_RPATH}")
+else()
+  if(BUILD_SHARED_LIBS)
+    set(p "${CMAKE_INSTALL_FULL_LIBDIR}")
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${p}" i)
+    if("${i}" STREQUAL "-1")
+      set(Base_rpath "${p}")
+    endif()
+  endif()
+endif()
+
+# Append non-standard external dependency directories, if any.
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 # Check integrity of node structure when compiled as debug
 add_compile_options($<$<CONFIG:Debug>:-DCMARK_DEBUG_NODES>)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,6 @@ add_library(cmark
   xml.c)
 cmark_add_compile_options(cmark)
 set_target_properties(cmark PROPERTIES
-  MACOSX_RPATH TRUE
   OUTPUT_NAME "cmark"
   # Avoid name clash between PROGRAM and LIBRARY pdb files.
   PDB_NAME libcmark

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,8 @@ add_executable(cmark_exe
   main.c)
 cmark_add_compile_options(cmark_exe)
 set_target_properties(cmark_exe PROPERTIES
-  OUTPUT_NAME "cmark")
+  OUTPUT_NAME "cmark"
+  INSTALL_RPATH "${Base_rpath}")
 target_link_libraries(cmark_exe PRIVATE
   cmark)
 


### PR DESCRIPTION
Before this commit, the `cmark` executable didn&rsquo;t inform the dynamic linker where to look for the `libcmark` shared object; this becomes an irritation when `libcmark` is installed in an unorthodox location:

<pre>
$ <a href="https://man7.org/linux/man-pages/man1/ldd.1.html">ldd</a> <b>/path/to/installed/files</b>/bin/cmark
        linux-gate.so.1 (0xb7ed7000)
        libcmark.so.0.31.0 => <b>not found</b>
        libc.so.6 => /usr/lib/libc.so.6 (0xb7cf3000)
        /lib/ld-linux.so.2 => /usr/lib/ld-linux.so.2 (0xb7ed8000)
</pre>

Because of this commit, the `cmark` executable&rsquo;s `rpath`<sup>\[[0](https://sourceware.org/binutils/docs-2.42/ld/Options.html#index-runtime-library-search-path)\]\[[1](https://cmake.org/cmake/help/v3.29/variable/CMAKE_INSTALL_RPATH.html)\]</sup> setting (or equivalent) is set upon installation, thereby providing the required search directory:

<pre>
$ <a href="https://man7.org/linux/man-pages/man1/ldd.1.html">ldd</a> <b>/path/to/installed/files</b>/bin/cmark
        linux-gate.so.1 (0xb7ef2000)
        libcmark.so.0.31.0 => <b>/path/to/installed/files/lib/libcmark.so.0.31.0 (0xb7e95000)</b>
        libc.so.6 => /usr/lib/libc.so.6 (0xb7cbc000)
        /lib/ld-linux.so.2 => /usr/lib/ld-linux.so.2 (0xb7ef3000)
</pre>

In particular, `rpath` is set to the following value:

<pre>"${<a href="https://cmake.org/cmake/help/v3.29/variable/CMAKE_INSTALL_PREFIX.html">CMAKE_INSTALL_PREFIX</a>}/${<a href="https://cmake.org/cmake/help/v3.29/module/GNUInstallDirs.html">CMAKE_INSTALL_LIBDIR</a>}"</pre>

Of course, this will only help on a system that supports an `rpath` feature known to `cmake`. Windows has no such feature anyway, apparently.