### PR TITLE
Fix CI and memory leak in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,17 @@ jobs:
           - '-DBUILD_SHARED_LIBS=YES'
           - ''
         compiler:
-          - c: 'clang -gdwarf-4'
-            cpp: 'clang++ -gdwarf-4'
+          - c: 'clang'
+            cpp: 'clang++'
+            cflags: '-gdwarf-4'
           - c: 'gcc'
             cpp: 'g++'
     env:
        CMAKE_OPTIONS: ${{ matrix.cmake_opts }}
        CC: ${{ matrix.compiler.c }}
        CXX: ${{ matrix.compiler.cpp }}
+       CFLAGS: ${{ matrix.compiler.cflags }}
+       CXXFLAGS: ${{ matrix.compiler.cflags }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,9 @@ jobs:
          sudo apt install -y valgrind
     - name: Build and test
       run: |
-         make debug
-         make test
+         cmake $CMAKE_OPTIONS -DCMAKE_BUILD_TYPE=Debug -S . -B build
+         cmake --build build
+         ctest --test-dir build --output-on-failure
          make leakcheck
 
   macos:
@@ -80,11 +81,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build and test
-      env:
-         CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=NO
       run: |
-         make debug
-         make test
+         cmake $CMAKE_OPTIONS -DCMAKE_BUILD_TYPE=Debug -S . -B build
+         cmake --build build
+         ctest --test-dir build --output-on-failure
 
   windows:
 
@@ -103,6 +103,7 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Build and test
       run: |
-        chcp 65001
-        nmake.exe /nologo /f Makefile.nmake test
+        cmake %CMAKE_OPTIONS%  -DCMAKE_BUILD_TYPE=Debug -S . -B build
+        cmake --build build
+        ctest --test-dir build -C Debug --output-on-failure
       shell: cmd

--- a/api_test/main.c
+++ b/api_test/main.c
@@ -927,6 +927,7 @@ static void sub_document(test_batch_runner *runner) {
         item);
     cmark_parser_feed(parser, markdown, sizeof(markdown) - 1);
     OK(runner, cmark_parser_finish(parser) != NULL, "parser_finish_0");
+    cmark_parser_free(parser);
   }
 
   {
@@ -940,6 +941,7 @@ static void sub_document(test_batch_runner *runner) {
         item);
     cmark_parser_feed(parser, markdown, sizeof(markdown) - 1);
     OK(runner, cmark_parser_finish(parser) != NULL, "parser_finish_0");
+    cmark_parser_free(parser);
   }
 
   char *xml = cmark_render_xml(doc, CMARK_OPT_DEFAULT);
@@ -973,6 +975,7 @@ static void sub_document(test_batch_runner *runner) {
                         "\n"
                         "  - Bye “ <http://www.geocities.com>\n",
          "nested document CommonMark is as expected");
+  free(cmark);
 
   cmark_node_free(doc);
 }

--- a/test/cmark.py
+++ b/test/cmark.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from ctypes import CDLL, c_char_p, c_size_t, c_int, c_void_p
+from ctypes import *
 from subprocess import Popen, PIPE
 import platform
 import os
+
+class cmark_mem(Structure):
+    _fields_ = [("calloc", c_void_p),
+                ("realloc", c_void_p),
+                ("free", CFUNCTYPE(None, c_void_p))]
 
 def pipe_through_prog(prog, text):
     p1 = Popen(prog.split(), stdout=PIPE, stdin=PIPE, stderr=PIPE)
@@ -12,26 +17,47 @@ def pipe_through_prog(prog, text):
     return [p1.returncode, result.decode('utf-8'), err]
 
 def to_html(lib, text):
+    get_alloc = lib.cmark_get_default_mem_allocator
+    get_alloc.restype = POINTER(cmark_mem)
+    free_func = get_alloc().contents.free
+
     markdown = lib.cmark_markdown_to_html
-    markdown.restype = c_char_p
+    markdown.restype = POINTER(c_char)
     markdown.argtypes = [c_char_p, c_size_t, c_int]
+
     textbytes = text.encode('utf-8')
     textlen = len(textbytes)
     # 1 << 17 == CMARK_OPT_UNSAFE
-    result = markdown(textbytes, textlen, 1 << 17).decode('utf-8')
+    cstring = markdown(textbytes, textlen, 1 << 17)
+    result = string_at(cstring).decode('utf-8')
+    free_func(cstring)
+
     return [0, result, '']
 
 def to_commonmark(lib, text):
-    textbytes = text.encode('utf-8')
-    textlen = len(textbytes)
+    get_alloc = lib.cmark_get_default_mem_allocator
+    get_alloc.restype = POINTER(cmark_mem)
+    free_func = get_alloc().contents.free
+
     parse_document = lib.cmark_parse_document
     parse_document.restype = c_void_p
     parse_document.argtypes = [c_char_p, c_size_t, c_int]
+
     render_commonmark = lib.cmark_render_commonmark
-    render_commonmark.restype = c_char_p
+    render_commonmark.restype = POINTER(c_char)
     render_commonmark.argtypes = [c_void_p, c_int, c_int]
+
+    free_node = lib.cmark_node_free
+    free_node.argtypes = [c_void_p]
+
+    textbytes = text.encode('utf-8')
+    textlen = len(textbytes)
     node = parse_document(textbytes, textlen, 0)
-    result = render_commonmark(node, 0, 0).decode('utf-8')
+    cstring = render_commonmark(node, 0, 0)
+    result = string_at(cstring).decode('utf-8')
+    free_func(cstring)
+    free_node(node)
+
     return [0, result, '']
 
 class CMark:


### PR DESCRIPTION
It would be nice if we could test with ASan and UBSan in our CI. This requires shared libasan to make it work with our Python test suite. Python 3.10 also generates false positives with LSan. This might be fixed in later versions. But for some reason, I can't get `-fsanitize=address` to run on Github CI.