### PR TITLE
cmake: Fix build type checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(cmark
   LANGUAGES C CXX
   VERSION 0.31.0)
 
-if(CMAKE_BUILD_TYPE MATCHES "asan|ubsan")
+if(CMAKE_BUILD_TYPE STREQUAL Asan)
   list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
   include(FindAsan)
 endif()
@@ -85,10 +85,10 @@ function(cmark_add_compile_options target)
             -Wall -Wextra -pedantic
             $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>)
   endif()
-  if(CMAKE_BUILD_TYPE MATCHES profile)
+  if(CMAKE_BUILD_TYPE STREQUAL Profile)
     target_compile_options(${target} PRIVATE -pg)
   endif()
-  if(CMAKE_BUILD_TYPE MATCHES ubsan)
+  if(CMAKE_BUILD_TYPE STREQUAL Ubsan)
     target_compile_options(${target} PRIVATE -fsanitize=undefined)
   endif()
   if(CMARK_LIB_FUZZER)

--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,12 @@ afl:
 	    $(CMARK) $(CMARK_OPTS)
 
 libFuzzer:
-	CC=clang CXX=clang++ \
-	CFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address \
-	    cmake -S . -B $(BUILDDIR) \
-	        -DCMARK_LIB_FUZZER=ON
+	cmake \
+	    -S . -B $(BUILDDIR) \
+	    -DCMAKE_C_COMPILER=clang \
+	    -DCMAKE_CXX_COMPILER=clang++ \
+	    -DCMAKE_BUILD_TYPE=Asan \
+	    -DCMARK_LIB_FUZZER=ON
 	cmake --build $(BUILDDIR)
 	mkdir -p fuzz/corpus
 	$(BUILDDIR)/fuzz/cmark-fuzz \


### PR DESCRIPTION
Commits 023d887d and c7b28771 broke the build type checks (regex is case-sensitive).

Make the libFuzzer target use the Asan build type again.