### PR TITLE
Add .vs (folders automatically generated by Visual Studio) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ bstrlib.txt
 build
 cmark.dSYM/*
 cmark
+
+# Visual Studio CMake support
+/.vs/
+/out/


### PR DESCRIPTION
Based on https://github.com/github/gitignore/blob/main/VisualStudio.gitignore (it contains extra files for C#/F#/VB.NET)

This change will ignore files generated when the folder is opened by Visual Studio:

![image](https://github.com/user-attachments/assets/9515b21d-4627-40ea-852b-7ac9d35ba3ec)

Visual Studio supports the test execution:

![image](https://github.com/user-attachments/assets/f115f266-fcb6-48c6-8fb8-61807a512dd3)
