### PR TITLE
[cjk branch] Revert "Add Yijing Hexagram Symbols to CJK"

### DIFF
--- a/src/utf8.c
+++ b/src/utf8.c
@@ -455,9 +455,8 @@ int cmark_utf8proc_is_CJK(int32_t uc) {
        || (uc >= 0x31f0 && uc <= 0x31ff) // Katakana Phonetic Extensions
        || (uc >= 0x3200 && uc <= 0x32ff) // Enclosed CJK Letters & Months
        || (uc >= 0x3300 && uc <= 0x33ff) // CJK Compatibility
-       || (uc >= 0x3400 && uc <= 0x4dbf) // CJK Unified Ideographs Extension A 
-       || (uc >= 0x4dc0 && uc <= 0x4dff) // Yijing Hexagram Symbols
-       || (uc >= 0x4e00 && uc <= 0x9fff) // CJK Unified Ideographs
+       || (uc >= 0x3400 && */ uc <= 0x4dbf) // CJK Unified Ideographs Extension A
+       || (uc >= 0x4e00 && /* uc <= 0x9fff) // CJK Unified Ideographs
        || (uc >= 0xa000 && uc <= 0xa48f) // Yi Syllables
        || (uc >= 0xa490 && */ uc <= 0xa4cf) // Yi Radicals
        || (uc >= 0xf900 && uc <= 0xfaff) // CJK Compatibility Ideographs


### PR DESCRIPTION
This reverts commit 922fffbc7925e49e4be3894c3c7576199bb533c1.

There are Yijing Trigram Symbols (U+2630-U+2637) in Miscellaneous Symbols block. We need to keep consistency with them.
The number of product terms is the same when we adopt both or neither as CJK.

https://github.com/commonmark/commonmark-spec/issues/650#issuecomment-2367339589