### PR TITLE
Makefile: Clean up cmake invocations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ indent_size = 2
 trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 8
+
+[Makefile.nmake]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+Makefile.nmake eol=crlf

--- a/Makefile
+++ b/Makefile
@@ -153,11 +153,11 @@ update-spec:
 	curl 'https://raw.githubusercontent.com/jgm/CommonMark/master/spec.txt'\
  > $(SPEC)
 
-test: $(SPEC) cmake_build
+test: cmake_build
 	ctest --test-dir $(BUILDDIR) --output-on-failure || (cat $(BUILDDIR)/Testing/Temporary/LastTest.log && exit 1)
 
-$(ALLTESTS): $(SPEC)
-	python3 test/spec_tests.py --spec $< --dump-tests | python3 -c 'import json; import sys; tests = json.loads(sys.stdin.read()); print("\n".join([test["markdown"] for test in tests]))' > $@
+$(ALLTESTS):
+	python3 test/spec_tests.py --spec $(SPEC) --dump-tests | python3 -c 'import json; import sys; tests = json.loads(sys.stdin.read()); print("\n".join([test["markdown"] for test in tests]))' > $@
 
 leakcheck: $(ALLTESTS)
 	for format in html man xml latex commonmark; do \

--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -7,26 +7,22 @@ PROG=$(BUILDDIR)\src\cmark.exe
 GENERATOR=NMake Makefiles
 
 all: $(BUILDDIR)/CMakeFiles
-	@cd $(BUILDDIR) && $(MAKE) /nologo && cd ..
+	cmake --build $(BUILDDIR)
 
 $(BUILDDIR)/CMakeFiles:
-	@-mkdir $(BUILDDIR) 2> nul
-	cd $(BUILDDIR) && \
 	cmake \
-	    -G "$(GENERATOR)" \
+	    -S . -B $(BUILDDIR) -G "$(GENERATOR)" \
 	    -D CMAKE_BUILD_TYPE=$(BUILD_TYPE) \
-	    -D CMAKE_INSTALL_PREFIX=$(INSTALLDIR) \
-	    .. && \
-	cd ..
+	    -D CMAKE_INSTALL_PREFIX=$(INSTALLDIR)
 
 install: all
-	@cd $(BUILDDIR) && $(MAKE) /nologo install && cd ..
+	cmake --install $(BUILDDIR)
 
 clean:
 	-rmdir /s /q $(BUILDDIR) $(MINGW_INSTALLDIR) 2> nul
 
 test: $(SPEC) all
-	@cd $(BUILDDIR) && $(MAKE) /nologo test ARGS="-V" && cd ..
+	ctest --test-dir $(BUILDDIR) --output-on-failure
 
 distclean: clean
 	del /q src\scanners.c 2> nul

--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -2,7 +2,6 @@ SRCDIR=src
 DATADIR=data
 BUILDDIR=build
 INSTALLDIR=windows
-SPEC=test/spec.txt
 PROG=$(BUILDDIR)\src\cmark.exe
 GENERATOR=NMake Makefiles
 
@@ -21,7 +20,7 @@ install: all
 clean:
 	-rmdir /s /q $(BUILDDIR) $(MINGW_INSTALLDIR) 2> nul
 
-test: $(SPEC) all
+test: all
 	ctest --test-dir $(BUILDDIR) --output-on-failure
 
 distclean: clean

--- a/README.md
+++ b/README.md
@@ -84,19 +84,15 @@ For a more portable method, you can use [cmake] manually. [cmake] knows
 how to create build environments for many build systems.  For example,
 on FreeBSD:
 
-    mkdir build
-    cd build
-    cmake ..  # optionally: -DCMAKE_INSTALL_PREFIX=path
-    make      # executable will be created as build/src/cmark
-    make test
-    make install
+    cmake -S . -B build  # optionally: -DCMAKE_INSTALL_PREFIX=path
+    cmake --build build  # executable will be created as build/src/cmark
+    ctest --test-dir build
+    cmake --install build
 
 Or, to create Xcode project files on OSX:
 
-    mkdir build
-    cd build
-    cmake -G Xcode ..
-    open cmark.xcodeproj
+    cmake -S . -B build -G Xcode
+    open build/cmark.xcodeproj
 
 The GNU Makefile also provides a few other targets for developers.
 To run a benchmark:


### PR DESCRIPTION
Use cmake command to build and install instead of invoking make. Also use -G option consistently. This allows to use other generators like Ninja:

    make GENERATOR=Ninja

Use cmake -B option instead of switching directories.