### PR TITLE
[cmake] Remove handling CMP0063

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
 
-if(POLICY CMP0063)
-  cmake_policy(SET CMP0063 NEW)
-endif()
 if(POLICY CMP0092)
   cmake_policy(SET CMP0092 NEW)
 endif()


### PR DESCRIPTION
Required CMake is 3.7 which automatically sets
CMP0063 to NEW.