### PR TITLE
Refactor: Use O(1) dereferencing for string emptiness checks instead of strlen()

### DIFF
--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -429,7 +429,7 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
         LIT("](");
         OUT(cmark_node_get_url(node), false, URL);
         title = cmark_node_get_title(node);
-        if (strlen(title) > 0) {
+        if (title[0]) {
           LIT(" \"");
           OUT(title, false, TITLE);
           LIT("\"");
@@ -446,7 +446,7 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       LIT("](");
       OUT(cmark_node_get_url(node), false, URL);
       title = cmark_node_get_title(node);
-      if (strlen(title) > 0) {
+      if (title[0]) {
         OUT(" \"", allow_wrap, LITERAL);
         OUT(title, false, TITLE);
         LIT("\"");

--- a/src/main.c
+++ b/src/main.c
@@ -126,7 +126,7 @@ int main(int argc, char *argv[]) {
       i += 1;
       if (i < argc) {
         width = (int)strtol(argv[i], &unparsed, 10);
-        if (unparsed && strlen(unparsed) > 0) {
+        if (unparsed && unparsed[0]) {
           fprintf(stderr, "failed parsing width '%s' at '%s'\n", argv[i],
                   unparsed);
           exit(1);


### PR DESCRIPTION
Using `strlen(str) > 0` to check for empty strings incurs an unnecessary O(N) cost, especially inside node rendering functions where it might be called repeatedly. 

Checking the first character `str[0]` is the idiomatic C approach for an O(1) emptiness check.

This PR updates `src/commonmark.c` and `src/main.c` to use this safer and more performant approach, preventing potential performance bottlenecks on large documents with extensive attributes.