### PR TITLE
Fix: Add errno check to strtol for detecting out-of-range width values

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -131,9 +131,13 @@ int main(int argc, char *argv[]) {
           fprintf(stderr, "width value out of range: '%s'\n", argv[i]);
           exit(1);
         }
-        if (unparsed && unparsed[0]) {
+        if (unparsed == argv[i] || (unparsed && unparsed[0])) {
           fprintf(stderr, "failed parsing width '%s' at '%s'\n", argv[i],
                   unparsed);
+          exit(1);
+        }
+        if (width < 0) {
+          fprintf(stderr, "width must be >= 0: '%s'\n", argv[i]);
           exit(1);
         }
       } else {

--- a/src/main.c
+++ b/src/main.c
@@ -125,7 +125,12 @@ int main(int argc, char *argv[]) {
     } else if (strcmp(argv[i], "--width") == 0) {
       i += 1;
       if (i < argc) {
+        errno = 0;
         width = (int)strtol(argv[i], &unparsed, 10);
+        if (errno == ERANGE) {
+          fprintf(stderr, "width value out of range: '%s'\n", argv[i]);
+          exit(1);
+        }
         if (unparsed && unparsed[0]) {
           fprintf(stderr, "failed parsing width '%s' at '%s'\n", argv[i],
                   unparsed);


### PR DESCRIPTION
Resolves #614
Added errno = 0 before parsing and an ERANGE check afterwards to safely exit with an error message when out-of-range width values are provided.