### PR TITLE
Enable clang-tidy checks explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,15 @@ libFuzzer:
 
 lint: $(BUILDDIR)
 	errs=0 ; \
-	for f in `ls src/*.[ch] | grep -v "scanners.c"` ; \
-	  do echo $$f ; clang-tidy -header-filter='^build/.*' -p=build -warnings-as-errors='*' $$f || errs=1 ; done ; \
+	for f in `ls src/*.[ch] | grep -v "scanners.c"` ; do \
+	  echo $$f ; \
+	  clang-tidy \
+	    -checks='clang-analyzer-*' \
+	    -header-filter='^build/.*' \
+	    -p=build \
+	    -warnings-as-errors='*' \
+	    $$f || errs=1 ; \
+	done ; \
 	exit $$errs
 
 mingw:


### PR DESCRIPTION
clang 22 removed clang-analyzer-* from the default checks, see

- https://github.com/llvm/llvm-project/issues/146482
- https://releases.llvm.org/22.1.0/tools/clang/tools/extra/docs/ReleaseNotes.html#potentially-breaking-changes

This makes clang-tidy 22 abort with 'Error: no checks enabled'. Enable these checks explicitly.